### PR TITLE
Fix loading state in ColorSettings

### DIFF
--- a/frontend/src/pages/settings/ColorSettings.jsx
+++ b/frontend/src/pages/settings/ColorSettings.jsx
@@ -26,6 +26,7 @@ export default function ColorSettings() {
   const handleSaveColors = async () => {
     setMessage('')
     setError('')
+    setLoading(true)
     try {
       await saveSettings({
         colorMode,
@@ -40,6 +41,8 @@ export default function ColorSettings() {
     } catch (err) {
       console.error(err)
       setError('Failed to save color settings')
+    } finally {
+      setLoading(false)
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure save button is disabled while color settings save

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684033b40ec08321bfa63c142309063b