### PR TITLE
Fix profile redirect

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -50,7 +50,7 @@ export default function Profile() {
           </div>
         </div>
         <Link
-          to="/account-settings"
+          to="/settings/account"
           className="bg-primary hover:bg-primary/90 text-white font-mono text-code-sm py-2 px-4 rounded-code transition-colors"
         >
           Edit Profile


### PR DESCRIPTION
## Summary
- update `Edit Profile` link to new `/settings/account` route

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6840406834e88321b9c306354af43633