### PR TITLE
Fix bucket switching on company page

### DIFF
--- a/frontend/src/pages/CompanyPage.js
+++ b/frontend/src/pages/CompanyPage.js
@@ -104,8 +104,9 @@ export default function CompanyPage() {
       bucketFromUrl !== selectedBucket
     ) {
       setSelectedBucket(bucketFromUrl)
+    }
 
-  }, [bucketFromUrl, buckets, selectedBucket])
+  }, [bucketFromUrl, buckets])
 
 
   // ── Fetch company progress when company changes ────────────────────────


### PR DESCRIPTION
## Summary
- update effect dependencies so bucket switch updates URL correctly

## Testing
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684047e21e90832186044329b83ac106