### PR TITLE
Remove unused home page sections

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,15 +1,9 @@
 import React from 'react'
 import { useAuth } from '../context/AuthContext'
-import CompanyProgress from '../components/CompanyProgress'
 
 export default function Home() {
   const { user } = useAuth()
 
-  const exampleData = [
-    { bucket: 'Easy', total: 25, solved: 15 },
-    { bucket: 'Medium', total: 50, solved: 8 },
-    { bucket: 'Hard', total: 25, solved: 3 },
-  ]
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
@@ -20,23 +14,6 @@ export default function Home() {
         <p className="mt-2 text-gray-300 max-w-2xl">
           Select a company from the sidebar to view question buckets and track your progress. Mark questions as solved or take notes to keep track of your preparation.
         </p>
-      </div>
-
-      <CompanyProgress data={exampleData} />
-
-      <div className="bg-surface rounded-card p-card">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
-          <div className="mb-4 md:mb-0">
-            <h3 className="text-lg font-medium">Get started with your journey</h3>
-            <p className="text-gray-400 text-sm">Explore different companies and their interview questions</p>
-          </div>
-          <button
-            className="bg-secondary hover:bg-secondary/90 text-white py-2 px-4 rounded-code font-mono text-code-base"
-            onClick={() => alert('Use the sidebar to navigate between companies')}
-          >
-            Explore Companies
-          </button>
-        </div>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- clean up `Home` page layout
- drop placeholder company progress info
- remove Explore Companies button

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684124aab5e4832181270f24ff5f7cf0