### PR TITLE
Record bucket in user updates

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -83,4 +83,8 @@ export function fetchCompanyProgress(companyName) {
   return api.get(path);
 }
 
+export function fetchRecentBuckets(limit = 4) {
+  return api.get(`/api/recent-buckets?limit=${limit}`);
+}
+
 export default api;

--- a/frontend/src/components/QuestionsTable.js
+++ b/frontend/src/components/QuestionsTable.js
@@ -131,7 +131,11 @@ export default function QuestionsTable({
   // ─── Update a single question’s field (userDifficulty or solved) ────────
   const updateField = (questionId, field, value) => {
     api
-      .patch(`/api/questions/${questionId}`, { [field]: value })
+      .patch(`/api/questions/${questionId}`, {
+        [field]: value,
+        company,
+        bucket,
+      })
       .then(res => {
         const updates = Array.isArray(res.data) ? res.data : [res.data];
         setQuestions(prev =>
@@ -155,6 +159,8 @@ export default function QuestionsTable({
     api
       .patch('/api/questions/batch-meta', {
         ids: selected,
+        company,
+        bucket,
         ...fields,
       })
       .then(res => {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,15 +1,18 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
-import CompanyProgress from '../components/CompanyProgress'
+import { fetchRecentBuckets } from '../api'
 
 export default function Home() {
   const { user } = useAuth()
 
-  const exampleData = [
-    { bucket: 'Easy', total: 25, solved: 15 },
-    { bucket: 'Medium', total: 50, solved: 8 },
-    { bucket: 'Hard', total: 25, solved: 3 },
-  ]
+  const [recent, setRecent] = useState([])
+
+  useEffect(() => {
+    fetchRecentBuckets()
+      .then(res => setRecent(res.data.data || []))
+      .catch(() => setRecent([]))
+  }, [])
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
@@ -22,42 +25,24 @@ export default function Home() {
         </p>
       </div>
 
-      <CompanyProgress data={exampleData} />
-
-      <div className="bg-surface rounded-card p-card">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
-          <div className="mb-4 md:mb-0">
-            <h3 className="text-lg font-medium">Get started with your journey</h3>
-            <p className="text-gray-400 text-sm">Explore different companies and their interview questions</p>
-          </div>
-          <button
-            className="bg-secondary hover:bg-secondary/90 text-white py-2 px-4 rounded-code font-mono text-code-base"
-            onClick={() => alert('Use the sidebar to navigate between companies')}
-          >
-            Explore Companies
-          </button>
-        </div>
-      </div>
-
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="bg-surface rounded-card p-card">
-          <h3 className="text-lg font-medium mb-2">Quick Actions</h3>
-          <div className="space-y-2">
-            <button className="w-full text-left bg-primary hover:bg-primary/90 text-white py-2 px-3 rounded-code text-sm flex items-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M7 9a2 2 0 012-2h6a2 2 0 012 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2V9z" />
-                <path d="M5 3a2 2 0 00-2 2v6a2 2 0 002 2V5h8a2 2 0 00-2-2H5z" />
-              </svg>
-              View all questions
-            </button>
-            <button className="w-full text-left bg-secondary hover:bg-secondary/90 text-white py-2 px-3 rounded-code text-sm flex items-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-                <path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd" />
-              </svg>
-              Review marked questions
-            </button>
-          </div>
+          <h3 className="text-lg font-medium mb-2">Recent Buckets</h3>
+          {recent.length === 0 ? (
+            <p className="text-sm text-gray-400">No recent activity.</p>
+          ) : (
+            <div className="space-y-2">
+              {recent.map((r) => (
+                <Link
+                  key={`${r.company}-${r.bucket}`}
+                  to={`/company/${encodeURIComponent(r.company)}?bucket=${encodeURIComponent(r.bucket)}`}
+                  className="block w-full text-left bg-primary hover:bg-primary/90 text-white py-2 px-3 rounded-code text-sm"
+                >
+                  {r.company} – {r.bucket}
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="bg-surface rounded-card p-card">


### PR DESCRIPTION
## Summary
- record company/bucket when updating question metadata
- update `/api/recent-buckets` to group by those fields
- filter user meta per bucket when listing questions
- send company and bucket in question update requests

## Testing
- `CI=true npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684124aab5e4832181270f24ff5f7cf0