### PR TITLE
Add sidebar transition animation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,7 +53,7 @@ function AppContent() {
         {onSettingsRoute ? (
           <SettingsSidebar />
         ) : (
-          sidebarOpen && <Sidebar sidebarOpen={sidebarOpen} />
+          <Sidebar sidebarOpen={sidebarOpen} />
         )}
 
         <main className="flex-1 overflow-auto p-4">

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -14,7 +14,7 @@ const BUCKET_LABELS = {
   'All':              'All',
 }
 
-export default function Sidebar() {
+export default function Sidebar({ sidebarOpen }) {
   const { user } = useAuth()
   const [filter, setFilter] = useState('')
   const [companies, setCompanies] = useState([])
@@ -104,7 +104,7 @@ export default function Sidebar() {
     <>
       {user && (
         <aside
-          className="
+          className={`
             /* ───────────────────────────────────────────────────────── */
             /* On mobile (< md): fixed sidebar under Navbar */
             fixed top-16 left-0 bottom-0 z-50
@@ -113,11 +113,14 @@ export default function Sidebar() {
             md:relative md:top-0 md:block
 
             /* Basic styling */
-            w-64 bg-gradient-to-b from-surface via-gray-900 to-surface
+            bg-gradient-to-b from-surface via-gray-900 to-surface
             border-r border-gray-800 shadow-elevation
             overflow-y-auto sidebar-scroll
+
+            transform transition-all duration-300
+            ${sidebarOpen ? 'w-64 translate-x-0' : 'w-0 -translate-x-full'}
             /* ───────────────────────────────────────────────────────── */
-          "
+          `}
         >
           {/*
             ── “pt-2 px-card” ensures:


### PR DESCRIPTION
## Summary
- keep sidebar mounted and pass `sidebarOpen` prop
- animate sidebar open/close via width and transform transitions

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6841303c8354832182f5346ead1b543a