### PR TITLE
Add UI transition improvements

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -64,3 +64,8 @@ body {
   width: 1em;
   margin-left: -1em;
 }
+
+/* Scroll reveal animations */
+.reveal { opacity: 0; transform: translateY(1rem); transition: opacity 0.5s ease, transform 0.5s ease; }
+.reveal.in-view { opacity: 1; transform: translateY(0); }
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -150,15 +150,15 @@ function SyncToast() {
     return () => clearTimeout(timerId)
   }, [syncResult])
 
-  if (!visible) return null
-
   const text = syncing
     ? 'Syncing solved questions…'
     : `Synced ${syncResult} questions`
 
   return (
     <div
-      className="fixed bottom-4 right-4 bg-gray-800 border border-gray-700 rounded-code p-2 pl-3 shadow-elevation-md flex items-center z-50 text-gray-100"
+      className={`fixed bottom-4 right-4 bg-gray-800 border border-gray-700 rounded-code p-2 pl-3 shadow-elevation-md flex items-center z-50 text-gray-100 transform transition-all duration-300 ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+      }`}
     >
       {syncing && (
         <div

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -233,7 +233,7 @@ export default function Navbar({
         ReactDOM.createPortal(
           <div
             ref={portalRef}
-            className={`bg-surface border border-gray-700 rounded-code shadow-lg z-50 transform transition-all duration-300 ${
+            className={`bg-surface border border-gray-700 rounded-code shadow-lg z-50 transform transition-all duration-300 ease-out ${
               isUserMenuOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
             }`}
             style={{

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -133,8 +133,8 @@ export default function Sidebar({ sidebarOpen }) {
             border-r border-gray-800 shadow-elevation
             overflow-y-auto sidebar-scroll
 
-            transform transition-all duration-300
-            ${sidebarOpen ? 'w-64 translate-x-0' : 'w-0 -translate-x-full'}
+            transform transition-all duration-300 opacity-0
+            ${sidebarOpen ? 'opacity-100 w-64 translate-x-0' : 'opacity-0 w-0 -translate-x-full'}
             /* ───────────────────────────────────────────────────────── */
           `}
         >

--- a/frontend/src/pages/CompanyPage.js
+++ b/frontend/src/pages/CompanyPage.js
@@ -222,30 +222,35 @@ export default function CompanyPage() {
             </button>
           </div>
 
-          {showAnalytics ? (
-            loadingTopics ? (
-              <div className="text-sm text-gray-500 italic">Loading analytics...</div>
-            ) : (
-              <div className="space-y-8">
-                {/* ── 1) CompanyProgress is now only shown here ─────────────── */}
-                <div className="rounded-xl bg-surface border border-gray-800 shadow-elevation p-4">
-                  <CompanyProgress data={progressData} loading={loadingProgress} />
-                </div>
+          <div className="relative">
+            <div
+              className={`transition-opacity duration-300 ${showAnalytics ? 'opacity-100' : 'opacity-0 pointer-events-none absolute inset-0'}`}
+            >
+              {loadingTopics ? (
+                <div className="text-sm text-gray-500 italic">Loading analytics...</div>
+              ) : (
+                <div className="space-y-8">
+                  {/* ── 1) CompanyProgress is now only shown here ─────────────── */}
+                  <div className="rounded-xl bg-surface border border-gray-800 shadow-elevation p-4">
+                    <CompanyProgress data={progressData} loading={loadingProgress} />
+                  </div>
 
-                {/* ── 2) Then show TopicsDashboard below it ────────────────── */}
-                <div className="rounded-xl bg-surface border border-gray-800 shadow-elevation p-4">
-                  <TopicsDashboard
-                    data={topics}
-                    onTagClick={tag => {
-                      setSelectedTag(tag)
-                      setShowAnalytics(false)
-                    }}
-                  />
+                  {/* ── 2) Then show TopicsDashboard below it ────────────────── */}
+                  <div className="rounded-xl bg-surface border border-gray-800 shadow-elevation p-4">
+                    <TopicsDashboard
+                      data={topics}
+                      onTagClick={tag => {
+                        setSelectedTag(tag)
+                        setShowAnalytics(false)
+                      }}
+                    />
+                  </div>
                 </div>
-              </div>
-            )
-          ) : (
-            <>
+              )}
+            </div>
+            <div
+              className={`transition-opacity duration-300 ${showAnalytics ? 'opacity-0 pointer-events-none absolute inset-0' : 'opacity-100'}`}
+            >
               {selectedTag && (
                 <div className="text-sm text-gray-400 mb-2">
                   <strong>Filtered by topic:</strong> {selectedTag}{' '}
@@ -268,8 +273,8 @@ export default function CompanyPage() {
                   refreshKey={refreshKey}
                 />
               </div>
-            </>
-          )}
+            </div>
+          </div>
         </>
       )}
     </div>

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,13 +1,29 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import logo from '../assets/logo.png'
 
 export default function Landing() {
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in-view')
+            observer.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.1 }
+    )
+
+    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
   return (
     <div className="min-h-screen flex flex-col bg-background text-gray-200 font-mono">
 
       {/* Hero */}
-      <section className="hero-gradient flex flex-col items-center justify-center text-center py-section px-card flex-grow">
+      <section className="hero-gradient flex flex-col items-center justify-center text-center py-section px-card flex-grow reveal opacity-0 translate-y-4">
         <h1 className="text-4xl md:text-5xl font-bold mb-6">
           Ace technical interviews,<br className="hidden md:block" />
           <span className="text-primary">company by company</span>
@@ -22,7 +38,7 @@ export default function Landing() {
       </section>
 
       {/* Features */}
-      <section className="bg-background py-section px-card">
+      <section className="bg-background py-section px-card reveal opacity-0 translate-y-4">
         <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center">
           <div>
             <h2 className="text-3xl font-bold mb-6">Your Complete Interview Preparation Companion</h2>
@@ -41,7 +57,7 @@ export default function Landing() {
       </section>
 
       {/* Call to action */}
-      <section className="bg-surface py-section px-card text-center">
+      <section className="bg-surface py-section px-card text-center reveal opacity-0 translate-y-4">
         <h2 className="text-3xl font-bold mb-6">Ready to level up your interview game?</h2>
         <p className="text-gray-400 mb-8">Join thousands of developers who have aced their technical interviews with LeetEase.</p>
         <Link to="/register" className="px-6 py-3 rounded-code bg-primary text-white hover:bg-primary/90 transition-colors">Start for Free</Link>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -157,10 +157,12 @@ export default function Register() {
           </div>
         )}
 
-        {/* Step 1: Registration Form */}
-        {step === 1 && (
-          <form onSubmit={handleSubmitForm} className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+        <div className="relative">
+          <div
+            className={`transition-opacity duration-300 ${step === 1 ? 'opacity-100' : 'opacity-0 pointer-events-none absolute inset-0'}`}
+          >
+            <form onSubmit={handleSubmitForm} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="block text-code-sm text-gray-300 font-mono mb-1">
                   First Name <span className="text-red-500">*</span>
@@ -272,13 +274,13 @@ export default function Register() {
             >
               Request OTP
             </button>
-          </form>
-        )}
-
-        {/* Step 2: OTP Verification */}
-        {step === 2 && (
-          <form onSubmit={handleSubmitOtp} className="space-y-4">
-            <div>
+            </form>
+          </div>
+          <div
+            className={`transition-opacity duration-300 ${step === 2 ? 'opacity-100' : 'opacity-0 pointer-events-none absolute inset-0'}`}
+          >
+            <form onSubmit={handleSubmitOtp} className="space-y-4">
+              <div>
               <p className="text-code-sm text-gray-300 font-mono mb-4">
                 A 6-digit code was sent to{' '}
                 <span className="text-primary">{formData.email}</span>. Enter it below:
@@ -314,8 +316,9 @@ export default function Register() {
             >
               Back
             </button>
-          </form>
-        )}
+            </form>
+          </div>
+        </div>
 
         {/* Footer Links */}
         <div className="mt-6 text-center">


### PR DESCRIPTION
## Summary
- smooth sidebar slide with opacity
- ease the avatar dropdown animation
- animate sync toast slide/fade
- crossfade company analytics and questions table
- fade between register steps
- reveal landing page sections on scroll
- add CSS for reveal animations

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68413906ecc08321895b0e4cc856f5ce