### PR TITLE
Add spinner indicators for loading states

### DIFF
--- a/frontend/src/components/QuestionsTable.js
+++ b/frontend/src/components/QuestionsTable.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import api from '../api';
 import { useAuth } from '../context/AuthContext';
+import Spinner from './Spinner';
 
 const PAGE_SIZE = 50;
 
@@ -295,9 +296,9 @@ export default function QuestionsTable({
               <tr>
                 <td
                   colSpan={Object.keys(SORT_FIELDS).length + 3}
-                  className="px-4 py-4 text-center italic text-gray-400"
+                  className="px-4 py-4 text-center"
                 >
-                  Loading…
+                  <Spinner size={20} className="mx-auto" />
                 </td>
               </tr>
             ) : questions.length ? (

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import api from '../api'
 import { useAuth } from '../context/AuthContext'
+import Spinner from './Spinner'
 
 // Map raw bucket keys (from the API) to human-friendly labels
 const BUCKET_LABELS = {
@@ -198,8 +199,8 @@ export default function Sidebar({ sidebarOpen }) {
                     {isExpanded && (
                       <ul className="ml-4 mt-1 space-y-1 border-l border-gray-700 pl-2">
                         {buckets === undefined ? (
-                          <li className="font-mono text-code-sm text-gray-500 px-2 py-1">
-                            Loading…
+                          <li className="px-2 py-1 flex justify-center">
+                            <Spinner size={16} />
                           </li>
                         ) : buckets.length > 0 ? (
                           buckets.map(rawBucketName => {

--- a/frontend/src/components/Spinner.jsx
+++ b/frontend/src/components/Spinner.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Spinner({ size = 16, className = '' }) {
+  return (
+    <div
+      className={`border-2 border-gray-600 border-t-primary rounded-full animate-spin ${className}`}
+      style={{ width: size, height: size }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- show a small spinner when the sidebar bucket list is loading
- show a spinner inside QuestionsTable while question data loads
- add reusable `Spinner` component

## Testing
- `npm install`
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_68415ae524408321a4d6673cef6b3a44