### PR TITLE
Fix settings sidebar toggle

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -49,7 +49,7 @@ function AppContent() {
       {/* ─── Below Navbar: either SettingsSidebar or Sidebar + main content ─ */}
       <div className="flex flex-1 overflow-hidden pt-16">
         {onSettingsRoute ? (
-          <SettingsSidebar />
+          <SettingsSidebar sidebarOpen={sidebarOpen} />
         ) : (
           <Sidebar sidebarOpen={sidebarOpen} />
         )}

--- a/frontend/src/components/SettingsSidebar.js
+++ b/frontend/src/components/SettingsSidebar.js
@@ -9,22 +9,25 @@ const LINKS = [
   { to: 'leetcode',  label: 'LeetCode' },
 ]
 
-export default function SettingsSidebar() {
+export default function SettingsSidebar({ sidebarOpen }) {
   return (
     <aside
-      className="
+      className={`
         /* ───────────────────────────────────────────────────────── */
         /* On mobile (< md): fixed sidebar under the Navbar  */
         fixed top-16 left-0 bottom-0 z-50
 
         /* Basic sidebar styling */
-        w-64 bg-surface border-r border-gray-800 shadow-elevation
+        bg-surface border-r border-gray-800 shadow-elevation
         overflow-y-auto sidebar-scroll
+
+        transform transition-all duration-300 opacity-0
+        ${sidebarOpen ? 'opacity-100 w-64 translate-x-0' : 'opacity-0 w-0 -translate-x-full'}
 
         /* On desktop (>= md): revert to a normal in-flow element */
         md:relative md:top-0 md:block
         /* ───────────────────────────────────────────────────────── */
-      "
+      `}
     >
       <div className="pt-2 px-card">
         {/* Sidebar header */}


### PR DESCRIPTION
## Summary
- pass sidebar state to the Settings sidebar
- animate the settings sidebar to match company sidebar behavior

## Testing
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68417895407083218bf906da0e13f331