### PR TITLE
Restrict import menu to admins

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -258,13 +258,15 @@ export default function Navbar({
             >
               Profile
             </Link>
-            <Link
-              to="/import"
-              onClick={closeUserMenu}
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
-            >
-              Import Questions
-            </Link>
+            {user?.role === 'admin' && (
+              <Link
+                to="/import"
+                onClick={closeUserMenu}
+                className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
+              >
+                Import Questions
+              </Link>
+            )}
             <Link
               to="/settings"
               onClick={closeUserMenu}
@@ -296,13 +298,15 @@ export default function Navbar({
       {isMenuOpen && user && (
         <div className="md:hidden bg-surface border-t border-gray-800 z-50">
           <div className="px-card py-2 space-y-1">
-            <Link
-              to="/import"
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
-              onClick={toggleMenu}
-            >
-              Import Questions
-            </Link>
+            {user?.role === 'admin' && (
+              <Link
+                to="/import"
+                className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+                onClick={toggleMenu}
+              >
+                Import Questions
+              </Link>
+            )}
             <Link
               to="/profile"
               className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"


### PR DESCRIPTION
## Summary
- restrict Import Questions option to admin users in navbar menu

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841790d20888321b1e25252f5011f9a