### PR TITLE
Add email-based password reset

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -283,7 +283,11 @@ def forgot_password():
         expires_delta=timedelta(minutes=15)
     )
     msg = Message('Password Reset Token', recipients=[user['email']])
-    msg.body = f"Your reset token: {reset_token}\nExpires in 15 minutes."
+    body = f"Your reset token: {reset_token}\nExpires in 15 minutes."
+    if config.FRONTEND_URL:
+        link = f"{config.FRONTEND_URL.rstrip('/')}/reset-password?token={reset_token}"
+        body += f"\nReset link: {link}"
+    msg.body = body
     mail.send(msg)
     return jsonify({'msg': 'Password reset token sent via email'}), 200
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -56,6 +56,9 @@ MAIL_USERNAME = os.getenv("MAIL_USERNAME")
 MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
 MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "noreply@example.com")
 
+# Base URL of the frontend (used for password reset links)
+FRONTEND_URL = os.getenv("FRONTEND_URL")
+
 # ————————————————
 # File Uploads (Profile Photos)
 # ————————————————

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,8 @@ import PrivateRoute      from './components/PrivateRoute';
 
 import Login             from './pages/Login';
 import Register          from './pages/Register';
+import ForgotPassword    from './pages/ForgotPassword';
+import ResetPassword     from './pages/ResetPassword';
 import Landing           from './pages/Landing';
 import Home              from './pages/Home';
 import AdminImport       from './pages/AdminImport';
@@ -69,6 +71,8 @@ function AppContent() {
 
               <Route path="/login"    element={<Login />} />
               <Route path="/register" element={<Register />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/contact"  element={<Contact />} />
 
             <Route

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -33,6 +33,14 @@ export function verifyOtp(payload) {
   return api.post('/auth/verify', payload);
 }
 
+export function requestPasswordReset(email) {
+  return api.post('/auth/forgot-password', { email });
+}
+
+export function resetPassword(token, newPassword) {
+  return api.post('/auth/reset-password', { token, newPassword });
+}
+
 // ───────────────────────────────
 // Profile – Account & Photo
 // ───────────────────────────────

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -5,6 +5,8 @@ import { useNavigate } from 'react-router-dom'
 import api, {
   registerUser,
   verifyOtp,
+  requestPasswordReset,
+  resetPassword,
   getAccountProfile,
   updateAccountProfile,
   uploadProfilePhoto,
@@ -160,6 +162,16 @@ export function AuthProvider({ children }) {
     })
   }
 
+  // ─── Forgot password request ───────────────────────────────────────────
+  const requestReset = async (email) => {
+    await requestPasswordReset(email)
+  }
+
+  // ─── Finalize password reset ───────────────────────────────────────────
+  const finalizeReset = async (token, newPassword) => {
+    await resetPassword(token, newPassword)
+  }
+
   return (
     <AuthContext.Provider
       value={{
@@ -178,6 +190,8 @@ export function AuthProvider({ children }) {
         editAccountProfile,
         changeProfilePhoto,
         removeProfilePhoto,
+        requestReset,
+        finalizeReset,
       }}
     >
       {children}

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+export default function ForgotPassword() {
+  const { requestReset } = useAuth()
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [sent, setSent] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await requestReset(email)
+      setSent(true)
+    } catch (err) {
+      console.error(err)
+      setError(err.response?.data?.description || 'Failed to send reset email.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900 p-4">
+        <div className="max-w-sm w-full bg-surface border border-gray-700 rounded-card shadow-elevation px-card py-6 space-y-4">
+          <h1 className="text-code-lg text-primary font-mono text-center">Check Your Email</h1>
+          <p className="text-gray-300 text-code-base text-center">
+            If that email exists, a reset link has been sent.
+          </p>
+          <Link to="/login" className="text-primary hover:underline text-center block">
+            Back to login
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 p-4">
+      <div className="relative max-w-sm w-full bg-surface border border-gray-700 rounded-card shadow-elevation px-card py-6 space-y-4">
+        {loading && (
+          <div className="absolute inset-0 bg-gray-800/70 flex flex-col items-center justify-center z-50 rounded-card">
+            <div className="w-12 h-12 border-4 border-gray-600 border-t-primary rounded-full animate-spin mb-4"></div>
+            <p className="text-gray-300 text-code-base">Sending…</p>
+          </div>
+        )}
+        <h1 className="text-code-lg text-primary font-mono text-center">Forgot Password</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label className="block text-code-sm text-gray-300 font-mono">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={loading}
+              className="w-full bg-gray-800 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+            />
+          </div>
+          {error && <p className="text-red-400 text-code-sm font-mono">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-primary hover:bg-primary/90 text-white font-mono text-code-base py-2 px-4 rounded-code transition-colors disabled:opacity-50"
+          >
+            Send Reset Email
+          </button>
+        </form>
+        <p className="text-center text-code-sm text-gray-400 font-mono">
+          Remembered?{' '}
+          <Link to="/login" className="text-primary hover:underline">
+            Back to login
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -82,14 +82,16 @@ export default function Login() {
             {loading ? 'Signing in…' : 'Login'}
           </button>
         </form>
+        <p className="text-center text-code-sm text-gray-400 font-mono mt-2">
+          <Link to="/forgot-password" className="text-primary hover:underline">
+            Forgot password?
+          </Link>
+        </p>
 
         {/* Registration Link */}
         <p className="text-center text-code-sm text-gray-400 font-mono">
           Don't have an account?{' '}
-          <Link
-            to="/register"
-            className="text-primary hover:underline"
-          >
+          <Link to="/register" className="text-primary hover:underline">
             Register
           </Link>
         </p>

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+export default function ResetPassword() {
+  const { finalizeReset } = useAuth()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+
+  const initialToken = searchParams.get('token') || ''
+  const [token, setToken] = useState(initialToken)
+  const [form, setForm] = useState({ newPassword: '', confirmPassword: '' })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    if (!token.trim()) {
+      setError('Reset token is required.')
+      return
+    }
+    if (form.newPassword.length < 8) {
+      setError('Password must be at least 8 characters.')
+      return
+    }
+    if (form.newPassword !== form.confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await finalizeReset(token.trim(), form.newPassword)
+      setSuccess(true)
+      setTimeout(() => navigate('/login'), 2000)
+    } catch (err) {
+      console.error(err)
+      setError(err.response?.data?.description || 'Failed to reset password.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900 p-4">
+        <div className="max-w-sm w-full bg-surface border border-gray-700 rounded-card shadow-elevation px-card py-6 space-y-4">
+          <h1 className="text-code-lg text-primary font-mono text-center">Password Reset</h1>
+          <p className="text-gray-300 text-code-base text-center">Your password has been updated.</p>
+          <Link to="/login" className="text-primary hover:underline text-center block">Continue to login</Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 p-4">
+      <div className="relative max-w-sm w-full bg-surface border border-gray-700 rounded-card shadow-elevation px-card py-6 space-y-4">
+        {loading && (
+          <div className="absolute inset-0 bg-gray-800/70 flex flex-col items-center justify-center z-50 rounded-card">
+            <div className="w-12 h-12 border-4 border-gray-600 border-t-primary rounded-full animate-spin mb-4"></div>
+            <p className="text-gray-300 text-code-base">Saving…</p>
+          </div>
+        )}
+        <h1 className="text-code-lg text-primary font-mono text-center">Reset Password</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {!initialToken && (
+            <div className="space-y-2">
+              <label className="block text-code-sm text-gray-300 font-mono">Reset Token</label>
+              <input
+                type="text"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          )}
+          <div className="space-y-2">
+            <label className="block text-code-sm text-gray-300 font-mono">New Password</label>
+            <input
+              type="password"
+              name="newPassword"
+              value={form.newPassword}
+              onChange={handleChange}
+              minLength="8"
+              required
+              className="w-full bg-gray-800 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="block text-code-sm text-gray-300 font-mono">Confirm Password</label>
+            <input
+              type="password"
+              name="confirmPassword"
+              value={form.confirmPassword}
+              onChange={handleChange}
+              minLength="8"
+              required
+              className="w-full bg-gray-800 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          {error && <p className="text-red-400 text-code-sm font-mono">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-primary hover:bg-primary/90 text-white font-mono text-code-base py-2 px-4 rounded-code transition-colors disabled:opacity-50"
+          >
+            Reset Password
+          </button>
+        </form>
+        <p className="text-center text-code-sm text-gray-400 font-mono">
+          <Link to="/login" className="text-primary hover:underline">Back to login</Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/settings/AccountSettings.jsx
+++ b/frontend/src/pages/settings/AccountSettings.jsx
@@ -19,9 +19,7 @@ export default function AccountSettings() {
     firstName: '',
     lastName: '',
     college: '',
-    email: '',
-    password: '',
-    confirmPassword: ''
+    email: ''
   })
   const [profilePhotoUrl, setProfilePhotoUrl] = useState(null)
   const [newPhotoFile, setNewPhotoFile] = useState(null)
@@ -36,9 +34,7 @@ export default function AccountSettings() {
           firstName: data.firstName || '',
           lastName: data.lastName || '',
           college: data.college || '',
-          email: data.email || '',
-          password: '',
-          confirmPassword: ''
+          email: data.email || ''
         })
         setProfilePhotoUrl(data.profilePhoto || null)
       } catch (err) {
@@ -73,16 +69,6 @@ export default function AccountSettings() {
       setError('Invalid email format.')
       return
     }
-    if (formData.password) {
-      if (formData.password.length < 8) {
-        setError('New password must be at least 8 characters.')
-        return
-      }
-      if (formData.password !== formData.confirmPassword) {
-        setError('Passwords do not match.')
-        return
-      }
-    }
 
     const payload = {
       firstName: formData.firstName.trim(),
@@ -90,18 +76,10 @@ export default function AccountSettings() {
       college:   formData.college.trim() || null,
       email:     formData.email.trim().toLowerCase()
     }
-    if (formData.password) {
-      payload.newPassword = formData.password
-    }
 
     try {
       setLoading(true)
       await editAccountProfile(payload)
-      setFormData(prev => ({
-        ...prev,
-        password: '',
-        confirmPassword: ''
-      }))
       setError('')
     } catch (err) {
       console.error(err)
@@ -226,35 +204,12 @@ export default function AccountSettings() {
           />
         </div>
 
-        <div>
-          <label className="block text-code-sm text-gray-300 font-mono mb-1">
-            New Password
-          </label>
-          <input
-            type="password"
-            name="password"
-            value={formData.password}
-            onChange={handleChange}
-            placeholder="Leave blank to keep existing"
-            className="w-full bg-gray-900 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary/50"
-          />
-        </div>
 
-        {formData.password && (
-          <div>
-            <label className="block text-code-sm text-gray-300 font-mono mb-1">
-              Confirm Password <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="password"
-              name="confirmPassword"
-              value={formData.confirmPassword}
-              onChange={handleChange}
-              required
-              className="w-full bg-gray-900 border border-gray-700 rounded-code px-3 py-2 text-code-base text-gray-100 font-mono placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary/50"
-            />
-          </div>
-        )}
+        <p className="text-center text-code-sm text-gray-400 font-mono">
+          <Link to="/forgot-password" className="text-primary hover:underline">
+            Reset password via email
+          </Link>
+        </p>
 
         <button
           type="submit"


### PR DESCRIPTION
## Summary
- add frontend URL config for reset link in emails
- include reset link in password reset email
- expose password-reset functions in API and auth context
- implement ForgotPassword and ResetPassword pages
- wire up routes and link from login page
- remove inline password change fields from account settings
- link to password reset from Account Settings

## Testing
- `npm ci`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6841786302d08321a6fa82dee9b8c656