### PR TITLE
Add mandatory secrets check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LeetEase
+
+This repository contains a React frontend and a Flask backend.
+
+## Backend Environment Variables
+
+The backend expects certain security keys to be set before it starts:
+
+- `SECRET_KEY`: Flask's secret key used for sessions.
+- `JWT_SECRET_KEY`: key used to sign JWT tokens.
+
+If either variable is missing, the application will raise a `RuntimeError` at startup.
+Define them in your `.env` file or export them in your deployment environment.

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,7 +10,9 @@ load_dotenv()  # loads variables from your .env
 # ————————————————
 # Flask Core
 # ————————————————
-SECRET_KEY = os.getenv("SECRET_KEY", "change-me-to-a-random-secret")
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY not set in environment")
 
 # ————————————————
 # MongoDB
@@ -26,7 +28,9 @@ def get_db():
 # ————————————————
 # Flask-JWT-Extended
 # ————————————————
-JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "also-change-me")
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+if not JWT_SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY not set in environment")
 # How long access tokens last
 JWT_ACCESS_TOKEN_EXPIRES = timedelta(
     seconds=int(os.getenv("JWT_ACCESS_TOKEN_EXPIRES", 3600))


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY and JWT_SECRET_KEY are provided
- document secret key requirements

## Testing
- `python3 -m py_compile backend/config.py backend/app.py backend/extensions.py $(find backend/modules -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841c18687b8832182cbe0850161ba9d