### PR TITLE
Default secure JWT cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# LeetEase
+
+This repository contains a Flask backend and React frontend.
+
+## Deployment Notes
+
+- JWT authentication cookies are configured to be sent only over HTTPS by default.
+- When running the backend locally without HTTPS, set:
+
+  ```bash
+  export JWT_COOKIE_SECURE=False
+  ```
+
+- Use HTTPS in production so that authentication works correctly.
+

--- a/backend/config.py
+++ b/backend/config.py
@@ -33,7 +33,8 @@ JWT_ACCESS_TOKEN_EXPIRES = timedelta(
 )
 # Store tokens in headers and cookies
 JWT_TOKEN_LOCATION = ["headers", "cookies"]
-JWT_COOKIE_SECURE = False       # Set to True in production (HTTPS)
+# Cookie is sent only over HTTPS by default. Override with JWT_COOKIE_SECURE=False for local testing.
+JWT_COOKIE_SECURE = os.getenv("JWT_COOKIE_SECURE", "True").lower() in ("true", "1", "yes")
 JWT_COOKIE_CSRF_PROTECT = True
 
 # ————————————————


### PR DESCRIPTION
## Summary
- default `JWT_COOKIE_SECURE` to `True`
- make it configurable via environment variable
- add deployment notes about HTTPS requirement

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c19624bc8321b48f22f650f5d002