### PR TITLE
Add configurable debug mode and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# LeetEase
+
+This project contains a Flask backend and a React frontend. The backend can run in either development or production mode.
+
+## Backend
+
+1. Install Python dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+2. Create a `.env` file in `backend/` with the required settings as described in `backend/config.py`.
+
+3. Run the server.
+
+### Development
+
+Enable Flask's debug mode by setting `FLASK_DEBUG=1`:
+
+```bash
+export FLASK_DEBUG=1
+python backend/app.py
+```
+
+### Production
+
+By default, debug mode is disabled. Simply run:
+
+```bash
+python backend/app.py
+```
+
+For a production deployment you may wish to run the app using a WSGI server such as Gunicorn.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1069,4 +1069,6 @@ def _startup_sync():
 if __name__ == '__main__':
     # If you want to perform a one-time sync on startup, uncomment below:
     # _startup_sync()
-    app.run(debug=True)
+    debug_env = os.getenv('FLASK_DEBUG', '').lower()
+    debug = debug_env in ('1', 'true', 'yes')
+    app.run(debug=debug)


### PR DESCRIPTION
## Summary
- make `FLASK_DEBUG` environment variable drive Flask debug mode
- document how to run the backend in development vs production

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841c19892f8832191550b01e66bfc05