### PR TITLE
Add authentication to profile photo route

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -74,6 +74,7 @@ def allowed_file(filename):
 
 # ─── Route to serve profile photos ────────────────────────────────────────
 @app.route('/uploads/profile_photos/<filename>')
+@jwt_required()
 def serve_profile_photo(filename):
     """Serve a saved profile photo from the upload folder."""
     upload_folder = current_app.config.get('UPLOAD_FOLDER')


### PR DESCRIPTION
## Summary
- protect `/uploads/profile_photos/<filename>` with `@jwt_required`

## Testing
- `pytest -q`
- `npm ci --prefix frontend`
- `CI=true npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6841c19f8548832190309cdf3f579bab