### PR TITLE
Fix duplicates in All bucket

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -682,8 +682,14 @@ def get_company_topics(company):
     uid      = get_jwt_identity()
 
     match = {'company_id': co['_id']}
+    # When "All" bucket is requested, restrict to the actual "All" bucket
+    # document instead of every bucket to avoid duplicates.
+    # The CSV/Excel dataset already contains a pre-made "All" bucket with
+    # unique questions, so querying all buckets would return duplicates.
     if bucket != 'All':
         match['bucket'] = bucket
+    else:
+        match['bucket'] = 'All'
 
     pipeline = [
         {'$match': match},
@@ -753,8 +759,12 @@ def list_questions(company, bucket):
     showUnsolved = request.args.get('showUnsolved', 'false').lower() == 'true'
 
     match = {'company_id': co['_id']}
+    # Show the dedicated "All" bucket instead of combining all buckets to
+    # avoid duplicates when viewing "All" questions for a company.
     if bucket != 'All':
         match['bucket'] = bucket
+    else:
+        match['bucket'] = 'All'
 
     pipeline = [
         {'$match': match},


### PR DESCRIPTION
## Summary
- restrict the `All` bucket to only fetch documents tagged as `All`
- also update topic endpoint for same behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cc9e4c7883218bbab4d3c76e0eb4