### PR TITLE
Implement error toast handling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { ErrorToastProvider } from './context/ErrorToastContext';
 import './App.css'; // Ensure this import remains
 
 import Navbar            from './components/Navbar';
@@ -194,7 +195,9 @@ export default function App() {
   return (
     <Router>
       <AuthProvider>
-        <AppContent />
+        <ErrorToastProvider>
+          <AppContent />
+        </ErrorToastProvider>
       </AuthProvider>
     </Router>
   );

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 // src/api.js
 import axios from 'axios';
 import Cookies from 'js-cookie';
+import { emitGlobalError } from './context/ErrorToastContext';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_API_URL || '',
@@ -21,6 +22,24 @@ api.interceptors.request.use(
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+// ─── Error toast interceptor ─────────────────────────────────────────────
+api.interceptors.response.use(
+  (response) => {
+    const msg = response.data?.description || response.data?.error;
+    if (msg) emitGlobalError(msg);
+    return response;
+  },
+  (error) => {
+    const msg =
+      error.response?.data?.description ||
+      error.response?.data?.error ||
+      error.message ||
+      'Network Error';
+    emitGlobalError(msg);
+    return Promise.reject(error);
+  }
 );
 
 // ───────────────────────────────

--- a/frontend/src/components/ErrorToast.jsx
+++ b/frontend/src/components/ErrorToast.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import colors from '../styles/colors'
+
+export default function ErrorToast({ message, visible, onClose }) {
+  return (
+    <div
+      className={`fixed bottom-4 right-4 rounded-code p-2 pl-3 shadow-elevation-md flex items-center z-50 transform transition-all duration-300 ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
+      style={{
+        background: colors.dark.surface,
+        border: `1px solid ${colors.dark.error}`,
+        color: colors.dark.error,
+      }}
+    >
+      <span className="pr-3">{message}</span>
+      <button
+        onClick={onClose}
+        className="ml-auto"
+        aria-label="Close"
+        style={{ color: colors.dark.gray[300] }}
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/context/ErrorToastContext.js
+++ b/frontend/src/context/ErrorToastContext.js
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import ErrorToast from '../components/ErrorToast'
+
+let globalHandler = () => {}
+export const setGlobalErrorHandler = (fn) => {
+  globalHandler = fn
+}
+export const emitGlobalError = (msg) => {
+  if (typeof globalHandler === 'function') {
+    globalHandler(msg)
+  }
+}
+
+const ErrorToastContext = createContext({ showError: () => {} })
+
+export function ErrorToastProvider({ children }) {
+  const [queue, setQueue] = useState([])
+  const [current, setCurrent] = useState(null)
+  const [visible, setVisible] = useState(false)
+
+  const showError = useCallback((msg) => {
+    if (!msg) return
+    setQueue(q => [...q, msg])
+  }, [])
+
+  useEffect(() => {
+    setGlobalErrorHandler(showError)
+  }, [showError])
+
+  useEffect(() => {
+    if (!current && queue.length > 0) {
+      setCurrent(queue[0])
+      setQueue(q => q.slice(1))
+      setVisible(true)
+    }
+  }, [queue, current])
+
+  useEffect(() => {
+    if (visible) {
+      const id = setTimeout(() => setVisible(false), 5000)
+      return () => clearTimeout(id)
+    }
+  }, [visible])
+
+  useEffect(() => {
+    if (!visible && current) {
+      const id = setTimeout(() => setCurrent(null), 300)
+      return () => clearTimeout(id)
+    }
+  }, [visible, current])
+
+  const handleClose = () => setVisible(false)
+
+  return (
+    <ErrorToastContext.Provider value={{ showError }}>
+      {children}
+      {current && (
+        <ErrorToast message={current} visible={visible} onClose={handleClose} />
+      )}
+    </ErrorToastContext.Provider>
+  )
+}
+
+export const useErrorToast = () => useContext(ErrorToastContext)
+export { emitGlobalError }

--- a/frontend/src/pages/AdminImport.jsx
+++ b/frontend/src/pages/AdminImport.jsx
@@ -34,7 +34,6 @@ export default function AdminImport() {
       setFile(null);  // reset picker
     } catch (err) {
       /* istanbul ignore next */
-      console.error(err);
       setMessage(
         err.response?.data?.description ||
         'Import failed. Please check the file format and try again.'
@@ -51,7 +50,6 @@ export default function AdminImport() {
       await backfillTags();
       setMessage('Tag backfill completed successfully.');
     } catch (err) {
-      console.error(err);
       setMessage(
         err.response?.data?.description || 'Backfill failed. Please try again.'
       );

--- a/frontend/src/pages/CompanyPage.js
+++ b/frontend/src/pages/CompanyPage.js
@@ -95,7 +95,7 @@ export default function CompanyPage() {
           }
         }
       })
-      .catch(console.error)
+      .catch(() => {})
       .finally(() => setBucketsLoading(false))
   }, [companyName])
 
@@ -119,8 +119,7 @@ export default function CompanyPage() {
     setLoadingProgress(true)
     fetchCompanyProgress(companyName)
       .then(res => setProgressData(res.data || []))
-      .catch(err => {
-        console.error('Failed to load company progress', err)
+      .catch(() => {
         setProgressData([])
       })
       .finally(() => setLoadingProgress(false))
@@ -141,7 +140,7 @@ export default function CompanyPage() {
         return res.json()
       })
       .then(json => setTopics(json.data))
-      .catch(console.error)
+      .catch(() => {})
       .finally(() => setLoadingTopics(false))
   }, [companyName, showAnalytics, selectedBucket, showUnsolved])
 

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -17,7 +17,6 @@ export default function ForgotPassword() {
       await requestReset(email)
       setSent(true)
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Failed to send reset email.')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -19,7 +19,6 @@ export default function Login() {
       await login(email, password)
       navigate('/home')
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Login failed')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -72,7 +72,6 @@ export default function Register() {
       // On success, backend has stored reg_data in session and emailed OTP
       setStep(2)
     } catch (err) {
-      console.error('Request OTP error:', err)
       const msg =
         err.response?.data?.message ||
         err.response?.data?.error ||
@@ -100,7 +99,6 @@ export default function Register() {
       // On success, registration is complete; redirect to login
       navigate('/login')
     } catch (err) {
-      console.error('Verify OTP error:', err)
       const msg =
         err.response?.data?.message ||
         err.response?.data?.error ||

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -42,7 +42,6 @@ export default function ResetPassword() {
       setSuccess(true)
       setTimeout(() => navigate('/login'), 2000)
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Failed to reset password.')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/settings/AccountSettings.jsx
+++ b/frontend/src/pages/settings/AccountSettings.jsx
@@ -38,7 +38,6 @@ export default function AccountSettings() {
         })
         setProfilePhotoUrl(data.profilePhoto || null)
       } catch (err) {
-        console.error(err)
         setError(err.response?.data?.description || 'Failed to load account data.')
       } finally {
         setLoading(false)
@@ -82,7 +81,6 @@ export default function AccountSettings() {
       await editAccountProfile(payload)
       setError('')
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Failed to update profile.')
     } finally {
       setLoading(false)
@@ -106,12 +104,11 @@ export default function AccountSettings() {
       const url = await changeProfilePhoto(form)
       setProfilePhotoUrl(url)
       setNewPhotoFile(null)
-    } catch (err) {
-      console.error(err)
+  } catch (err) {
       setError('Failed to upload photo.')
-    } finally {
+  } finally {
       setLoading(false)
-    }
+  }
   }
 
   const handleRemovePhoto = async () => {
@@ -120,12 +117,11 @@ export default function AccountSettings() {
     try {
       await removeProfilePhoto()
       setProfilePhotoUrl(null)
-    } catch (err) {
-      console.error(err)
+  } catch (err) {
       setError('Failed to remove photo.')
-    } finally {
+  } finally {
       setLoading(false)
-    }
+  }
   }
 
   if (loading) {

--- a/frontend/src/pages/settings/ColorSettings.jsx
+++ b/frontend/src/pages/settings/ColorSettings.jsx
@@ -39,7 +39,6 @@ export default function ColorSettings() {
       })
       setMessage('Color settings saved!')
     } catch (err) {
-      console.error(err)
       setError('Failed to save color settings')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/settings/LeetCodeSettings.jsx
+++ b/frontend/src/pages/settings/LeetCodeSettings.jsx
@@ -35,7 +35,6 @@ export default function LeetCodeSettings() {
       })
       setMessage('LeetCode profile saved')
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Save failed')
     }
   }
@@ -48,7 +47,6 @@ export default function LeetCodeSettings() {
       setMessage(`Synced ${count} questions`)
       window.dispatchEvent(new Event('leetSync'))
     } catch (err) {
-      console.error(err)
       setError(err.response?.data?.description || 'Sync failed')
     }
   }


### PR DESCRIPTION
## Summary
- show API errors via new ErrorToast component
- hook Axios responses to trigger the toast
- add ErrorToastProvider in App
- clean up manual console logging in pages

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d55e20f88321a9b8dca55967cc6b