### PR TITLE
Add centralized error extractor

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import Cookies from 'js-cookie';
 import { emitGlobalError } from './context/ErrorToastContext';
+import { extractErrorMessage } from './utils/error';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_API_URL || '',
@@ -32,11 +33,7 @@ api.interceptors.response.use(
     return response;
   },
   (error) => {
-    const msg =
-      error.response?.data?.description ||
-      error.response?.data?.error ||
-      error.message ||
-      'Network Error';
+    const msg = extractErrorMessage(error);
     emitGlobalError(msg);
     return Promise.reject(error);
   }

--- a/frontend/src/pages/AdminImport.jsx
+++ b/frontend/src/pages/AdminImport.jsx
@@ -1,6 +1,7 @@
 // src/pages/AdminImport.jsx
 import React, { useState } from 'react';
 import { uploadQuestions, backfillTags } from '../api';
+import { extractErrorMessage } from '../utils/error';
 
 export default function AdminImport() {
   const [file, setFile]       = useState(null);
@@ -35,7 +36,7 @@ export default function AdminImport() {
     } catch (err) {
       /* istanbul ignore next */
       setMessage(
-        err.response?.data?.description ||
+        extractErrorMessage(err) ||
         'Import failed. Please check the file format and try again.'
       );
     } finally {
@@ -51,7 +52,7 @@ export default function AdminImport() {
       setMessage('Tag backfill completed successfully.');
     } catch (err) {
       setMessage(
-        err.response?.data?.description || 'Backfill failed. Please try again.'
+        extractErrorMessage(err) || 'Backfill failed. Please try again.'
       );
     } finally {
       setIsBackfilling(false);

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { extractErrorMessage } from '../utils/error'
 
 export default function ForgotPassword() {
   const { requestReset } = useAuth()
@@ -17,7 +18,7 @@ export default function ForgotPassword() {
       await requestReset(email)
       setSent(true)
     } catch (err) {
-      setError(err.response?.data?.description || 'Failed to send reset email.')
+      setError(extractErrorMessage(err) || 'Failed to send reset email.')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { extractErrorMessage } from '../utils/error'
 
 export default function Login() {
   const { login } = useAuth()
@@ -19,7 +20,7 @@ export default function Login() {
       await login(email, password)
       navigate('/home')
     } catch (err) {
-      setError(err.response?.data?.description || 'Login failed')
+      setError(extractErrorMessage(err))
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import api from '../api'
+import { extractErrorMessage } from '../utils/error'
 import UniversityAutocomplete from '../components/UniversityAutocomplete.jsx'
 
 export default function Register() {
@@ -73,11 +74,9 @@ export default function Register() {
       // On success, backend has stored reg_data in session and emailed OTP
       setStep(2)
     } catch (err) {
-      const msg =
-        err.response?.data?.message ||
-        err.response?.data?.error ||
-        'Failed to request OTP'
-      setError(msg)
+      setError(
+        extractErrorMessage(err) || 'Failed to request OTP'
+      )
     } finally {
       setLoading(false)
     }
@@ -100,11 +99,9 @@ export default function Register() {
       // On success, registration is complete; redirect to login
       navigate('/login')
     } catch (err) {
-      const msg =
-        err.response?.data?.message ||
-        err.response?.data?.error ||
-        'Invalid or expired OTP'
-      setError(msg)
+      setError(
+        extractErrorMessage(err) || 'Invalid or expired OTP'
+      )
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { extractErrorMessage } from '../utils/error'
 
 export default function ResetPassword() {
   const { finalizeReset } = useAuth()
@@ -42,7 +43,7 @@ export default function ResetPassword() {
       setSuccess(true)
       setTimeout(() => navigate('/login'), 2000)
     } catch (err) {
-      setError(err.response?.data?.description || 'Failed to reset password.')
+      setError(extractErrorMessage(err) || 'Failed to reset password.')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/settings/AccountSettings.jsx
+++ b/frontend/src/pages/settings/AccountSettings.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { useAuth } from '../../context/AuthContext'
 import { Link } from 'react-router-dom'
 import UniversityAutocomplete from '../../components/UniversityAutocomplete.jsx'
+import { extractErrorMessage } from '../../utils/error'
 
 export default function AccountSettings() {
   const {
@@ -39,7 +40,7 @@ export default function AccountSettings() {
         })
         setProfilePhotoUrl(data.profilePhoto || null)
       } catch (err) {
-        setError(err.response?.data?.description || 'Failed to load account data.')
+        setError(extractErrorMessage(err) || 'Failed to load account data.')
       } finally {
         setLoading(false)
       }
@@ -82,7 +83,7 @@ export default function AccountSettings() {
       await editAccountProfile(payload)
       setError('')
     } catch (err) {
-      setError(err.response?.data?.description || 'Failed to update profile.')
+      setError(extractErrorMessage(err) || 'Failed to update profile.')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/settings/LeetCodeSettings.jsx
+++ b/frontend/src/pages/settings/LeetCodeSettings.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import { useAuth } from '../../context/AuthContext'
 import api from '../../api'
+import { extractErrorMessage } from '../../utils/error'
 
 export default function LeetCodeSettings() {
   const { user, syncBackground } = useAuth()
@@ -35,7 +36,7 @@ export default function LeetCodeSettings() {
       })
       setMessage('LeetCode profile saved')
     } catch (err) {
-      setError(err.response?.data?.description || 'Save failed')
+      setError(extractErrorMessage(err) || 'Save failed')
     }
   }
 
@@ -47,7 +48,7 @@ export default function LeetCodeSettings() {
       setMessage(`Synced ${count} questions`)
       window.dispatchEvent(new Event('leetSync'))
     } catch (err) {
-      setError(err.response?.data?.description || 'Sync failed')
+      setError(extractErrorMessage(err) || 'Sync failed')
     }
   }
 

--- a/frontend/src/utils/error.js
+++ b/frontend/src/utils/error.js
@@ -1,0 +1,9 @@
+export function extractErrorMessage(err) {
+  return (
+    err?.response?.data?.description ||
+    err?.response?.data?.error ||
+    (err?.response?.status === 401 ? 'Bad email or password' : null) ||
+    err?.message ||
+    'Network Error'
+  );
+}


### PR DESCRIPTION
## Summary
- add `extractErrorMessage` helper and use it in API interceptor
- simplify pages to use the helper for error handling
- ensure toast shows `Bad email or password` for 401s

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841da25a6a08321a823194e6313f61c