### PR TITLE
Fix spurious login error toast

### DIFF
--- a/frontend/src/utils/error.js
+++ b/frontend/src/utils/error.js
@@ -1,9 +1,18 @@
 export function extractErrorMessage(err) {
-  return (
-    err?.response?.data?.description ||
-    err?.response?.data?.error ||
-    (err?.response?.status === 401 ? 'Bad email or password' : null) ||
-    err?.message ||
-    'Network Error'
-  );
+  const description = err?.response?.data?.description;
+  const error = err?.response?.data?.error;
+
+  if (description || error) {
+    return description || error;
+  }
+
+  if (err?.response?.status === 401) {
+    const url = err?.config?.url || '';
+    if (url.includes('/auth/login')) {
+      return 'Bad email or password';
+    }
+    return 'Unauthorized';
+  }
+
+  return err?.message || 'Network Error';
 }


### PR DESCRIPTION
## Summary
- refine `extractErrorMessage` to only show 'Bad email or password' on `/auth/login`
- return generic 'Unauthorized' for other 401 errors

## Testing
- `pytest -q`
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68426fcf514c8321b77521c2c2313dac