### PR TITLE
Add dynamic user stats dashboard

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -115,4 +115,8 @@ export function fetchRecentBuckets(limit = 4) {
   return api.get(`/api/recent-buckets?limit=${limit}`);
 }
 
+export function fetchUserStats() {
+  return api.get('/api/user-stats');
+}
+
 export default api;

--- a/frontend/src/components/CircularProgress.jsx
+++ b/frontend/src/components/CircularProgress.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export default function CircularProgress({ size = 80, stroke = 8, progress = 0, color = '#38bdf8', bg = '#374151' }) {
+  const radius = (size - stroke) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (progress / 100) * circumference
+
+  return (
+    <svg width={size} height={size} className="transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={bg}
+        strokeWidth={stroke}
+        fill="transparent"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={color}
+        strokeWidth={stroke}
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import CircularProgress from './CircularProgress'
+import { fetchUserStats } from '../api'
+
+export default function UserStats() {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchUserStats()
+      .then(res => setStats(res.data))
+      .catch(() => setStats(null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="font-mono text-code-sm text-gray-500 italic">Loading stats…</div>
+    )
+  }
+
+  if (!stats) {
+    return (
+      <div className="font-mono text-code-sm text-gray-500 italic">Stats unavailable.</div>
+    )
+  }
+
+  const { totalSolved, totalAttempted, difficulty, companies } = stats
+  const pct = totalAttempted > 0 ? Math.round((totalSolved / totalAttempted) * 100) : 0
+  const diffColors = { Easy: '#8BC34A', Medium: '#FFB74D', Hard: '#E57373' }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-center">
+        <div className="relative">
+          <CircularProgress size={100} progress={pct} color="#38bdf8" />
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-xl font-medium">{totalSolved}</span>
+            <span className="text-gray-400 text-sm">Solved</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        {['Easy', 'Medium', 'Hard'].map(level => (
+          <div key={level} className="flex flex-col items-center">
+            <span className="text-lg font-medium" style={{ color: diffColors[level] }}>
+              {difficulty[level] || 0}
+            </span>
+            <span className="text-gray-400 text-sm">{level}</span>
+          </div>
+        ))}
+      </div>
+
+      {Array.isArray(companies) && companies.length > 0 && (
+        <div>
+          <h4 className="font-mono text-code-sm text-gray-300 mb-1">By Company</h4>
+          <ul className="text-sm space-y-1 max-h-40 overflow-y-auto pr-1">
+            {companies.map(c => (
+              <li key={c.company} className="flex justify-between">
+                <span>{c.company}</span>
+                <span>
+                  {c.solved} / {c.total}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { fetchRecentBuckets } from '../api'
+import UserStats from '../components/UserStats'
 
 
 export default function Home() {
@@ -53,24 +54,7 @@ export default function Home() {
 
         <div className="bg-surface rounded-card p-card">
           <h3 className="text-lg font-medium mb-2">Your Stats</h3>
-          <div className="grid grid-cols-2 gap-2 text-sm">
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">12</span>
-              <span className="text-gray-400">Solved</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">5</span>
-              <span className="text-gray-400">Today</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">3</span>
-              <span className="text-gray-400">Streak</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">78%</span>
-              <span className="text-gray-400">Accuracy</span>
-            </div>
-          </div>
+          <UserStats />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- implement `/api/user-stats` endpoint with caching
- create reusable `CircularProgress` component
- create `UserStats` panel that fetches and displays stats
- update Home page to show live stats
- expose `fetchUserStats` in frontend API

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68427ba6e3d08321ac5d7293e67ee34c