### PR TITLE
Add dynamic user stats dashboard

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -64,6 +64,10 @@ CQ        = db.company_questions
 USER_META = db.user_meta
 USERS     = db.users
 
+# Cache for per-user statistics (simple in-memory)
+STATS_CACHE = {}
+STATS_TTL_SECONDS = 60
+
 # ─── Error Handlers ───────────────────────────────────────────────────────
 @app.errorhandler(HTTPException)
 def handle_http_exception(e):
@@ -1130,6 +1134,81 @@ def recent_buckets():
     results = list(USER_META.aggregate(pipeline))
     return jsonify({'data': results}), 200
 
+# ─── Aggregate user statistics for Home page ─────────────────────────────
+@app.route('/api/user-stats', methods=['GET'])
+@jwt_required()
+def user_stats():
+    """Return solved/attempted counts and per-company breakdown."""
+    uid = get_jwt_identity()
+
+    cached = STATS_CACHE.get(uid)
+    now = datetime.utcnow()
+    if cached and (now - cached['ts']).total_seconds() < STATS_TTL_SECONDS:
+        return jsonify(cached['data']), 200
+
+    total_attempted = USER_META.count_documents({'user_id': uid})
+    total_solved = USER_META.count_documents({'user_id': uid, 'solved': True})
+
+    diff_pipeline = [
+        {'$match': {'user_id': uid, 'solved': True}},
+        {'$lookup': {
+            'from': 'questions',
+            'localField': 'question_id',
+            'foreignField': '_id',
+            'as': 'q'
+        }},
+        {'$unwind': '$q'},
+        {'$group': {'_id': '$q.leetDifficulty', 'count': {'$sum': 1}}}
+    ]
+    diff_counts = {d['_id']: d['count'] for d in USER_META.aggregate(diff_pipeline)}
+    for lvl in ['Easy', 'Medium', 'Hard']:
+        diff_counts.setdefault(lvl, 0)
+
+    company_pipeline = [
+        {'$match': {'bucket': 'All'}},
+        {'$lookup': {
+            'from': 'user_meta',
+            'let': {'qid': '$question_id'},
+            'pipeline': [
+                {'$match': {
+                    '$expr': {
+                        '$and': [
+                            {'$eq': ['$question_id', {'$toString': '$$qid'}]},
+                            {'$eq': ['$user_id', uid]},
+                            {'$eq': ['$solved', True]}
+                        ]
+                    }
+                }},
+                {'$project': {'_id': 0}}
+            ],
+            'as': 'meta'
+        }},
+        {'$lookup': {
+            'from': 'companies',
+            'localField': 'company_id',
+            'foreignField': '_id',
+            'as': 'co'
+        }},
+        {'$unwind': '$co'},
+        {'$group': {
+            '_id': '$co.name',
+            'total': {'$sum': 1},
+            'solved': {'$sum': {'$cond': [{'$gt': [{'$size': '$meta'}, 0]}, 1, 0]}}
+        }},
+        {'$project': {'company': '$_id', 'total': 1, 'solved': 1, '_id': 0}},
+        {'$sort': {'company': 1}}
+    ]
+    company_stats = list(CQ.aggregate(company_pipeline))
+
+    data = {
+        'totalSolved': total_solved,
+        'totalAttempted': total_attempted,
+        'difficulty': diff_counts,
+        'companies': company_stats
+    }
+    STATS_CACHE[uid] = {'ts': now, 'data': data}
+    return jsonify(data), 200
+
 # ─── Run & Startup Sync ────────────────────────────────────────────────────
 def _startup_sync():
     """Sync every user who has both handle & session saved."""
@@ -1157,6 +1236,30 @@ def _startup_sync():
                 fut.result()
             except Exception as e:
                 app.logger.warning("Startup sync failed for %s: %s", uid, e)
+
+# ─── Serve React Frontend ────────────────────────────────────────────────
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def serve_react(path: str):
+    """Serve the React single-page application."""
+    if path.startswith('api/') or path.startswith('uploads/'):
+        abort(404)
+
+    build_dir = os.path.join(os.getcwd(), 'frontend', 'build')
+    public_dir = os.path.join(os.getcwd(), 'frontend', 'public')
+
+    target = os.path.join(build_dir, path)
+    if os.path.exists(target) and os.path.isfile(target):
+        return send_from_directory(build_dir, path)
+
+    index_build = os.path.join(build_dir, 'index.html')
+    if os.path.exists(index_build):
+        return send_from_directory(build_dir, 'index.html')
+
+    target_public = os.path.join(public_dir, path)
+    if os.path.exists(target_public) and os.path.isfile(target_public):
+        return send_from_directory(public_dir, path)
+    return send_from_directory(public_dir, 'index.html')
 
 if __name__ == '__main__':
     # If you want to perform a one-time sync on startup, uncomment below:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -115,4 +115,8 @@ export function fetchRecentBuckets(limit = 4) {
   return api.get(`/api/recent-buckets?limit=${limit}`);
 }
 
+export function fetchUserStats() {
+  return api.get('/api/user-stats');
+}
+
 export default api;

--- a/frontend/src/components/CircularProgress.jsx
+++ b/frontend/src/components/CircularProgress.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export default function CircularProgress({ size = 80, stroke = 8, progress = 0, color = '#38bdf8', bg = '#374151' }) {
+  const radius = (size - stroke) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (progress / 100) * circumference
+
+  return (
+    <svg width={size} height={size} className="transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={bg}
+        strokeWidth={stroke}
+        fill="transparent"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={color}
+        strokeWidth={stroke}
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import CircularProgress from './CircularProgress'
+import { fetchUserStats } from '../api'
+
+export default function UserStats() {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchUserStats()
+      .then(res => setStats(res.data))
+      .catch(() => setStats(null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="font-mono text-code-sm text-gray-500 italic">Loading stats…</div>
+    )
+  }
+
+  if (!stats) {
+    return (
+      <div className="font-mono text-code-sm text-gray-500 italic">Stats unavailable.</div>
+    )
+  }
+
+  const { totalSolved, totalAttempted, difficulty, companies } = stats
+  const pct = totalAttempted > 0 ? Math.round((totalSolved / totalAttempted) * 100) : 0
+  const diffColors = { Easy: '#8BC34A', Medium: '#FFB74D', Hard: '#E57373' }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-center">
+        <div className="relative">
+          <CircularProgress size={100} progress={pct} color="#38bdf8" />
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-xl font-medium">{totalSolved}</span>
+            <span className="text-gray-400 text-sm">Solved</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        {['Easy', 'Medium', 'Hard'].map(level => (
+          <div key={level} className="flex flex-col items-center">
+            <span className="text-lg font-medium" style={{ color: diffColors[level] }}>
+              {difficulty[level] || 0}
+            </span>
+            <span className="text-gray-400 text-sm">{level}</span>
+          </div>
+        ))}
+      </div>
+
+      {Array.isArray(companies) && companies.length > 0 && (
+        <div>
+          <h4 className="font-mono text-code-sm text-gray-300 mb-1">By Company</h4>
+          <ul className="text-sm space-y-1 max-h-40 overflow-y-auto pr-1">
+            {companies.map(c => (
+              <li key={c.company} className="flex justify-between">
+                <span>{c.company}</span>
+                <span>
+                  {c.solved} / {c.total}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { fetchRecentBuckets } from '../api'
+import UserStats from '../components/UserStats'
 
 
 export default function Home() {
@@ -53,24 +54,7 @@ export default function Home() {
 
         <div className="bg-surface rounded-card p-card">
           <h3 className="text-lg font-medium mb-2">Your Stats</h3>
-          <div className="grid grid-cols-2 gap-2 text-sm">
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">12</span>
-              <span className="text-gray-400">Solved</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">5</span>
-              <span className="text-gray-400">Today</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">3</span>
-              <span className="text-gray-400">Streak</span>
-            </div>
-            <div className="bg-gray-900 rounded p-2 flex flex-col items-center">
-              <span className="text-xl font-medium">78%</span>
-              <span className="text-gray-400">Accuracy</span>
-            </div>
-          </div>
+          <UserStats />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- implement `/api/user-stats` endpoint with caching
- create reusable `CircularProgress` component
- create `UserStats` panel that fetches and displays stats
- update Home page to show live stats
- expose `fetchUserStats` in frontend API
- serve React app from Flask for SPA routing

## Testing
- `pytest -q`
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427ba6e3d08321ac5d7293e67ee34c