### PR TITLE
Show solved question ratio

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1140,7 +1140,8 @@ def user_stats():
     cached = STATS_CACHE.get(uid)
     now = datetime.utcnow()
     if cached and (now - cached['ts']).total_seconds() < STATS_TTL_SECONDS:
-        return jsonify(cached['data']), 200
+        if 'totalQuestions' in cached['data']:
+            return jsonify(cached['data']), 200
 
     total_attempted = USER_META.count_documents({'user_id': uid})
     total_solved = USER_META.count_documents({'user_id': uid, 'solved': True})
@@ -1212,9 +1213,12 @@ def user_stats():
     ]
     company_stats = list(CQ.aggregate(company_pipeline))
 
+    total_questions = sum(c['total'] for c in company_stats)
+
     data = {
         'totalSolved': total_solved,
         'totalAttempted': total_attempted,
+        'totalQuestions': total_questions,
         'difficulty': diff_counts,
         'companies': company_stats
     }

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -25,9 +25,10 @@ export default function UserStats() {
     )
   }
 
-  const { totalSolved, totalAttempted, difficulty } = stats
+  const { totalSolved, totalQuestions, difficulty } = stats
+  const totalQs = typeof totalQuestions === 'number' ? totalQuestions : 0
 
-  const pct = totalAttempted > 0 ? Math.round((totalSolved / totalAttempted) * 100) : 0
+  const pct = totalQs > 0 ? Math.round((totalSolved / totalQs) * 100) : 0
   const diffColors = { Easy: '#8BC34A', Medium: '#FFB74D', Hard: '#E57373' }
 
   return (
@@ -36,7 +37,7 @@ export default function UserStats() {
         <div className="relative">
           <CircularProgress size={100} progress={pct} color="#38bdf8" />
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className="text-xl font-medium">{totalSolved}</span>
+            <span className="text-xl font-medium">{totalSolved}/{totalQs}</span>
             <span className="text-gray-400 text-sm">Solved</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- compute total number of questions across all companies in `/api/user-stats`
- display solved/total question ratio in the user stats widget
- skip cached stats if they lack the new field
- guard against missing totals in the frontend

## Testing
- `CI=true npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68428479c2708321aaed3f22a87f27a7