### PR TITLE
Fix unauthorized toast on startup

### DIFF
--- a/frontend/src/utils/error.js
+++ b/frontend/src/utils/error.js
@@ -11,6 +11,10 @@ export function extractErrorMessage(err) {
     if (url.includes('/auth/login')) {
       return 'Bad email or password';
     }
+    if (url.includes('/auth/me')) {
+      // Silence unauthorized errors from the initial auth check
+      return '';
+    }
     return 'Unauthorized';
   }
 


### PR DESCRIPTION
## Summary
- adjust error extraction so 401 from `/auth/me` produces no toast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684656dd199c8321b3d65bc087cdce0f