### PR TITLE
Add basic theme toggle with persistence

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -9,12 +9,21 @@ body,
 #root {
   height: 100%;
   margin: 0;
-  background-color: #0d1117; /* use Tailwind “background” token (#0d1117) */
 }
 
-/* If you want to override Tailwind’s default body text color, you can add: */
 body {
-  color: #e2e8f0; /* a light gray for text on dark background, adjust to taste */
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+:root {
+  --background-color: #ffffff;
+  --text-color: #1f2937;
+}
+
+body.dark {
+  --background-color: #0d1117;
+  --text-color: #e2e8f0;
 }
 
 /* Custom scrollbar styling for sidebar components */

--- a/frontend/src/components/ErrorToast.jsx
+++ b/frontend/src/components/ErrorToast.jsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import colors from '../styles/colors'
+import { useTheme } from '../context/ThemeContext'
 
 export default function ErrorToast({ message, visible, onClose }) {
+  const { theme } = useTheme()
+  const palette = theme === 'dark' ? colors.dark : colors.light
   return (
     <div
       className={`fixed bottom-4 right-4 rounded-code p-2 pl-3 shadow-elevation-md flex items-center z-50 transform transition-all duration-300 ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
       style={{
-        background: colors.dark.surface,
-        border: `1px solid ${colors.dark.error}`,
-        color: colors.dark.error,
+        background: palette.surface,
+        border: `1px solid ${palette.error}`,
+        color: palette.error,
       }}
     >
       <span className="pr-3">{message}</span>
@@ -16,7 +19,7 @@ export default function ErrorToast({ message, visible, onClose }) {
         onClick={onClose}
         className="ml-auto"
         aria-label="Close"
-        style={{ color: colors.dark.gray[300] }}
+        style={{ color: palette.gray[300] }}
       >
         ×
       </button>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { useTheme } from '../context/ThemeContext'
 
 // Adjust this import path if your logo is stored elsewhere
 import logo from '../assets/logo.png'
@@ -15,6 +16,7 @@ export default function Navbar({
 }) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
+  const { theme, toggleTheme } = useTheme()
 
   // ─── Mobile Menu (“Import / Profile / Settings / Logout”) ────────────
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -274,6 +276,15 @@ export default function Navbar({
             >
               Settings
             </Link>
+            <button
+              onClick={() => {
+                toggleTheme()
+                closeUserMenu()
+              }}
+              className="w-full text-left font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
+            >
+              Switch to {theme === 'dark' ? 'Light' : 'Dark'} Theme
+            </button>
             <Link
               to="/contact"
               onClick={closeUserMenu}
@@ -321,6 +332,15 @@ export default function Navbar({
             >
               Settings
             </Link>
+            <button
+              onClick={() => {
+                toggleTheme()
+                toggleMenu()
+              }}
+              className="w-full text-left font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+            >
+              Switch to {theme === 'dark' ? 'Light' : 'Dark'} Theme
+            </button>
             <Link
               to="/contact"
               className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"

--- a/frontend/src/context/ThemeContext.js
+++ b/frontend/src/context/ThemeContext.js
@@ -1,0 +1,40 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const ThemeContext = createContext()
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('dark')
+
+  // Load stored preference on mount
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) {
+      setTheme(stored)
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    } else {
+      setTheme('light')
+    }
+  }, [])
+
+  // Apply theme class and persist
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.body.classList.add('dark')
+    } else {
+      document.body.classList.remove('dark')
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'))
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)
+

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './App.css';
 import App from './App';
+import { ThemeProvider } from './context/ThemeContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/styles/colors.js
+++ b/frontend/src/styles/colors.js
@@ -35,4 +35,37 @@ export default {
       900: '#161b22',
     }
   }
+  ,
+  light: {
+    background: '#ffffff',
+    surface: '#f3f4f6',
+    primary: '#1f6feb',
+    secondary: '#238636',
+    accent: '#d29922',
+    error: '#d73a49',
+    warning: '#e36209',
+    success: '#28a745',
+    info: '#0366d6',
+
+    code: {
+      keyword: '#cf222e',
+      function: '#8250df',
+      string: '#0a3069',
+      number: '#0550ae',
+      comment: '#6e7781',
+      variable: '#953800',
+    },
+
+    gray: {
+      100: '#fafbfc',
+      200: '#e1e4e8',
+      300: '#d1d5da',
+      400: '#959da5',
+      500: '#6a737d',
+      600: '#586069',
+      700: '#444d56',
+      800: '#2f363d',
+      900: '#24292e',
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add light palette alongside dark colors
- implement ThemeContext to persist user preference and apply `dark` class
- wrap app in the ThemeProvider
- add theme toggle option in navbar dropdown menus
- style body colors via CSS variables
- update ErrorToast to respect the active theme

## Testing
- `pytest -q`
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684656f5fc188321bedc691e00185956