### PR TITLE
Improve company stats UI on homepage

### DIFF
--- a/frontend/src/components/CompanyStats.jsx
+++ b/frontend/src/components/CompanyStats.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { fetchUserStats } from '../api'
+import LinearProgress from './LinearProgress'
 
 export default function CompanyStats() {
   const [companies, setCompanies] = useState([])
@@ -64,20 +65,23 @@ export default function CompanyStats() {
         </select>
       </div>
 
-      <ul className="text-sm space-y-1 max-h-60 overflow-y-auto pr-1">
+      <ul className="text-sm space-y-3 max-h-72 overflow-y-auto pr-1">
         {sorted.map(c => {
           const pctSolved = c.total ? Math.round((c.solved / c.total) * 100) : 0
           return (
-            <li key={c.company} className="flex justify-between">
-              <Link
-                to={`/company/${encodeURIComponent(c.company)}`}
-                className="text-primary hover:underline"
-              >
-                {c.company}
-              </Link>
-              <span>
-                {c.solved} / {c.total} ({pctSolved}%)
-              </span>
+            <li key={c.company} className="space-y-1">
+              <div className="flex justify-between items-center">
+                <Link
+                  to={`/company/${encodeURIComponent(c.company)}`}
+                  className="text-primary hover:underline"
+                >
+                  {c.company}
+                </Link>
+                <span className="text-gray-400">
+                  {c.solved} / {c.total}
+                </span>
+              </div>
+              <LinearProgress value={pctSolved} />
             </li>
           )
         })}

--- a/frontend/src/components/LinearProgress.jsx
+++ b/frontend/src/components/LinearProgress.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function LinearProgress({ value, className = '', color = 'bg-primary', bgColor = 'bg-gray-800' }) {
+  const pct = Math.max(0, Math.min(100, value))
+  return (
+    <div className={`w-full ${bgColor} h-2 rounded overflow-hidden ${className}`}>
+      <div
+        className={`${color} h-full transition-all duration-300`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -60,7 +60,7 @@ export default function Home() {
         </div>
 
         <div className="bg-surface rounded-card p-card md:col-span-2">
-          <h3 className="text-lg font-medium mb-2">By Company</h3>
+          <h3 className="text-lg font-medium mb-2">Company Progress</h3>
           <CompanyStats />
 
         </div>


### PR DESCRIPTION
## Summary
- add LinearProgress component
- enhance CompanyStats with progress bars
- tweak home page heading for company progress

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6846594581b48321b74956f3fa0172c5