### PR TITLE
Fix user stats denominator

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1213,7 +1213,9 @@ def user_stats():
     ]
     company_stats = list(CQ.aggregate(company_pipeline))
 
-    total_questions = sum(c['total'] for c in company_stats)
+    # Count unique questions across all companies (any bucket)
+    # This represents the denominator for solved stats
+    total_questions = len(CQ.distinct('question_id'))
 
     data = {
         'totalSolved': total_solved,


### PR DESCRIPTION
## Summary
- improve unique question counting in user stats endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465e0c48348321bf201658742fad23