### PR TITLE
Fix user stats denominator

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1213,7 +1213,14 @@ def user_stats():
     ]
     company_stats = list(CQ.aggregate(company_pipeline))
 
-    total_questions = sum(c['total'] for c in company_stats)
+    # Count unique question slugs across all companies to avoid duplicates
+    qids = CQ.distinct('question_id')
+    links = [q.get('link', '') for q in QUEST.find({'_id': {'$in': qids}}, {'link': 1})]
+    slugs = {
+        link.rstrip('/').split('/')[-1].split('?')[0].lower()
+        for link in links if link
+    }
+    total_questions = len(slugs)
 
     data = {
         'totalSolved': total_solved,


### PR DESCRIPTION
## Summary
- improve unique question counting in user stats endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68465e0c48348321bf201658742fad23