### PR TITLE
Fix light theme colors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,11 +36,11 @@ body {
 :root {
   /* Light theme variables */
 
-  --sidebar-track: #e8e0d1;
-  --sidebar-thumb: #c8bfae;
+  --sidebar-track: #e5e7eb;
+  --sidebar-thumb: #cbd5e1;
 
-  --color-background: 249 245 233;
-  --color-surface: 255 252 244;
+  --color-background: 255 255 255;
+  --color-surface: 245 245 245;
 
   --color-primary: 9 105 218;
   --color-secondary: 26 127 55;
@@ -56,16 +56,16 @@ body {
   --color-code-comment: 106 115 125;
   --color-code-variable: 227 98 9;
 
-  --color-gray-100: 254 252 247;
-  --color-gray-200: 239 231 215;
-  --color-gray-300: 220 212 196;
-  --color-gray-400: 192 180 160;
-  --color-gray-500: 160 146 122;
-  --color-gray-600: 128 116 96;
-  --color-gray-700: 105 93 76;
-  --color-gray-800: 77 69 56;
-  --color-gray-900: 52 46 36;
-  --color-text: 45 42 40;
+  --color-gray-100: 249 250 251;
+  --color-gray-200: 226 232 240;
+  --color-gray-300: 203 213 225;
+  --color-gray-400: 148 163 184;
+  --color-gray-500: 100 116 139;
+  --color-gray-600: 71 85 105;
+  --color-gray-700: 51 65 85;
+  --color-gray-800: 30 41 59;
+  --color-gray-900: 15 23 42;
+  --color-text: 31 41 55;
 
 }
 


### PR DESCRIPTION
## Summary
- adjust light theme grayscale for higher contrast

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684663bc55508321b88187a4790fb5fb