### PR TITLE
Improve light mode palette

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -42,19 +42,19 @@ body {
   --color-background: 249 245 233;
   --color-surface: 255 252 244;
 
-  --color-primary: 9 105 218;
-  --color-secondary: 26 127 55;
-  --color-accent: 227 121 51;
-  --color-error: 207 34 46;
-  --color-warning: 212 167 44;
-  --color-success: 45 164 78;
-  --color-info: 56 139 253;
-  --color-code-keyword: 215 58 73;
-  --color-code-function: 111 66 193;
-  --color-code-string: 3 47 98;
-  --color-code-number: 0 92 197;
-  --color-code-comment: 106 115 125;
-  --color-code-variable: 227 98 9;
+  --color-primary: 37 99 235;
+  --color-secondary: 16 185 129;
+  --color-accent: 217 119 6;
+  --color-error: 220 38 38;
+  --color-warning: 234 179 8;
+  --color-success: 5 150 105;
+  --color-info: 56 189 248;
+  --color-code-keyword: 199 58 61;
+  --color-code-function: 107 33 168;
+  --color-code-string: 29 78 216;
+  --color-code-number: 2 132 199;
+  --color-code-comment: 100 116 139;
+  --color-code-variable: 234 88 12;
 
   --color-gray-100: 254 252 247;
   --color-gray-200: 239 231 215;


### PR DESCRIPTION
## Summary
- refine light mode palette with calm colors
- keep dark theme unchanged

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684668c40ba083218b5d989f4a9c9014