### PR TITLE
Improve light sidebar style

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -118,14 +118,16 @@ export default function Navbar({
     : ''
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-surface border-b border-gray-800 shadow-elevation">
+    <header
+      className="fixed top-0 left-0 right-0 z-50 bg-gray-200 dark:bg-surface text-gray-900 dark:text-gray-100 border-b border-gray-800 shadow-elevation"
+    >
       <div className="relative flex items-center h-16 px-card">
         {/* ─── Left: Sidebar Toggle Button ───────────────────────────────────────── */}
         {user && (
           <div className="flex items-center">
             <button
             onClick={handleSidebarToggle}
-            className="text-gray-400 hover:text-gray-100 focus:outline-none mr-4"
+            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none mr-4"
             aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
           >
             {sidebarOpen ? (
@@ -174,7 +176,7 @@ export default function Navbar({
         <div className="ml-auto flex items-center gap-code">
           <button
             onClick={toggleTheme}
-            className="text-gray-400 hover:text-gray-100 focus:outline-none"
+            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none"
             aria-label="Toggle theme"
           >
             {theme === 'dark' ? (
@@ -254,13 +256,13 @@ export default function Navbar({
             <div className="hidden md:flex md:items-center md:gap-2">
               <Link
                 to="/contact"
-                className="font-mono text-code-sm bg-transparent hover:bg-gray-800 text-gray-400 hover:text-gray-100 px-3 py-1.5 rounded-code border border-gray-700 transition-colors duration-150"
+                className="font-mono text-code-sm bg-transparent hover:bg-gray-300 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 px-3 py-1.5 rounded-code border border-gray-700 transition-colors duration-150"
               >
                 Contact
               </Link>
               <Link
                 to="/login"
-                className="font-mono text-code-sm bg-transparent hover:bg-gray-800 text-gray-400 hover:text-gray-100 px-3 py-1.5 rounded-code border border-gray-700 transition-colors duration-150"
+                className="font-mono text-code-sm bg-transparent hover:bg-gray-300 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 px-3 py-1.5 rounded-code border border-gray-700 transition-colors duration-150"
               >
                 Login
               </Link>
@@ -280,7 +282,7 @@ export default function Navbar({
         ReactDOM.createPortal(
           <div
             ref={portalRef}
-            className={`bg-surface border border-gray-700 rounded-code shadow-lg z-50 transform transition-all duration-300 ease-out ${
+            className={`bg-gray-200 dark:bg-surface border border-gray-700 rounded-code shadow-lg z-50 transform transition-all duration-300 ease-out ${
               isUserMenuOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
             }`}
             style={{
@@ -293,7 +295,7 @@ export default function Navbar({
             <Link
               to="/profile"
               onClick={closeUserMenu}
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 rounded-t-code transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-4 py-2 rounded-t-code transition-colors duration-150"
             >
               Profile
             </Link>
@@ -301,7 +303,7 @@ export default function Navbar({
               <Link
                 to="/import"
                 onClick={closeUserMenu}
-                className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
+                className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-4 py-2 transition-colors duration-150"
               >
                 Import Questions
               </Link>
@@ -309,14 +311,14 @@ export default function Navbar({
             <Link
               to="/settings"
               onClick={closeUserMenu}
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-4 py-2 transition-colors duration-150"
             >
               Settings
             </Link>
             <Link
               to="/contact"
               onClick={closeUserMenu}
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-4 py-2 transition-colors duration-150"
             >
               Contact
             </Link>
@@ -325,7 +327,7 @@ export default function Navbar({
                 logout()
                 closeUserMenu()
               }}
-              className="w-full text-left font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 rounded-b-code transition-colors duration-150"
+              className="w-full text-left font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-4 py-2 rounded-b-code transition-colors duration-150"
             >
               Logout
             </button>
@@ -335,12 +337,12 @@ export default function Navbar({
 
       {/* ─── Mobile Menu Panel ─────────────────────────────────────────────────────── */}
       {isMenuOpen && user && (
-        <div className="md:hidden bg-surface border-t border-gray-800 z-50">
+        <div className="md:hidden bg-gray-200 dark:bg-surface border-t border-gray-800 z-50">
           <div className="px-card py-2 space-y-1">
             {user?.role === 'admin' && (
               <Link
                 to="/import"
-                className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+                className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-3 py-2 rounded-code transition-colors duration-150"
                 onClick={toggleMenu}
               >
                 Import Questions
@@ -348,21 +350,21 @@ export default function Navbar({
             )}
             <Link
               to="/profile"
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-3 py-2 rounded-code transition-colors duration-150"
               onClick={toggleMenu}
             >
               Profile
             </Link>
             <Link
               to="/settings"
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-3 py-2 rounded-code transition-colors duration-150"
               onClick={toggleMenu}
             >
               Settings
             </Link>
             <Link
               to="/contact"
-              className="block font-mono text-code-base text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+              className="block font-mono text-code-base text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-3 py-2 rounded-code transition-colors duration-150"
               onClick={toggleMenu}
             >
               Contact
@@ -373,7 +375,7 @@ export default function Navbar({
                   logout()
                   toggleMenu()
                 }}
-                className="w-full text-left font-mono text-code-sm text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-3 py-2 rounded-code transition-colors duration-150"
+                className="w-full text-left font-mono text-code-sm text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 px-3 py-2 rounded-code transition-colors duration-150"
               >
                 Logout
               </button>

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -130,7 +130,8 @@ export default function Sidebar({ sidebarOpen }) {
             md:relative md:top-0 md:block
 
             /* Basic styling */
-            bg-gradient-to-b from-surface via-gray-900 to-surface
+            bg-gray-200 dark:bg-surface
+            text-gray-900 dark:text-gray-100
             border-r border-gray-800 shadow-elevation
             overflow-y-auto sidebar-scroll
 
@@ -145,7 +146,7 @@ export default function Sidebar({ sidebarOpen }) {
                • On desktop, parent already has pt-16, so this is extra padding.
           */}
           <div className="pt-2 px-card">
-            <h2 className="font-mono text-lg md:text-xl text-gray-100 font-semibold mb-3">
+            <h2 className="font-mono text-lg md:text-xl text-gray-900 dark:text-gray-100 font-semibold mb-3">
               Companies
             </h2>
 
@@ -157,7 +158,7 @@ export default function Sidebar({ sidebarOpen }) {
               className="
                 font-mono text-code-sm w-full px-3 py-1.5 mb-2
                 rounded-code border border-gray-700 bg-gray-900
-                text-gray-100 placeholder-gray-500
+                text-gray-900 dark:text-gray-100 placeholder-gray-500
                 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/50
               "
             />
@@ -178,7 +179,7 @@ export default function Sidebar({ sidebarOpen }) {
                         ${
                           isActive
                             ? 'bg-gray-700 border-l-4 border-primary text-primary font-medium'
-                            : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                            : 'text-gray-800 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white'
                         }
                       `}
                     >
@@ -189,7 +190,7 @@ export default function Sidebar({ sidebarOpen }) {
                           e.stopPropagation()
                           toggleCompany(company)
                         }}
-                        className="text-gray-400 group-hover:text-primary p-1 rounded transition-colors duration-150 hover:bg-gray-800/40"
+                        className="text-gray-600 dark:text-gray-400 group-hover:text-primary p-1 rounded transition-colors duration-150 hover:bg-gray-300/40 dark:hover:bg-gray-800/40"
                         aria-label={isExpanded ? 'Collapse' : 'Expand'}
                       >
                         {isExpanded ? '−' : '+'}
@@ -217,7 +218,7 @@ export default function Sidebar({ sidebarOpen }) {
                                     transition-colors duration-150 focus:outline-none focus:ring-1 focus:ring-primary/50
                                     ${bucketActive
                                       ? 'bg-primary/20 text-primary font-semibold ring-1 ring-primary/50'
-                                      : 'text-gray-400 hover:text-primary hover:bg-gray-800/60'}
+                                      : 'text-gray-700 hover:bg-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800/60 dark:hover:text-primary'}
                                   `}
                                 >
                                   {BUCKET_LABELS[rawBucketName] || rawBucketName}
@@ -226,7 +227,7 @@ export default function Sidebar({ sidebarOpen }) {
                             )
                           })
                         ) : (
-                          <li className="font-mono text-code-sm text-gray-500 px-2 py-1">
+                          <li className="font-mono text-code-sm text-gray-600 dark:text-gray-500 px-2 py-1">
                             (No buckets)
                           </li>
                         )}


### PR DESCRIPTION
## Summary
- adjust sidebar color for light mode
- use darker beige background and dark text
- apply matching beige palette to navbar and menus

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68466bcfaf54832196a0c82d2884dc1e