### PR TITLE
Fix light mode colors

### DIFF
--- a/frontend/src/components/CompanyStats.jsx
+++ b/frontend/src/components/CompanyStats.jsx
@@ -50,14 +50,14 @@ export default function CompanyStats() {
   return (
     <div className="space-y-2">
       <div className="flex justify-end">
-        <label className="text-xs text-gray-400 mr-2" htmlFor="company-sort">
+        <label className="text-xs text-gray-600 dark:text-gray-400 mr-2" htmlFor="company-sort">
           Sort by
         </label>
         <select
           id="company-sort"
           value={sortBy}
           onChange={e => setSortBy(e.target.value)}
-          className="bg-gray-900 border border-gray-700 rounded-code text-xs px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-code text-xs px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
         >
           <option value="name">Name</option>
           <option value="solved">% Solved</option>
@@ -77,7 +77,7 @@ export default function CompanyStats() {
                 >
                   {c.company}
                 </Link>
-                <span className="text-gray-400">
+                <span className="text-gray-600 dark:text-gray-400">
                   {c.solved} / {c.total}
                 </span>
               </div>

--- a/frontend/src/components/LinearProgress.jsx
+++ b/frontend/src/components/LinearProgress.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function LinearProgress({ value, className = '', color = 'bg-primary', bgColor = 'bg-gray-800' }) {
+export default function LinearProgress({ value, className = '', color = 'bg-primary', bgColor = 'bg-gray-300 dark:bg-gray-800' }) {
   const pct = Math.max(0, Math.min(100, value))
   return (
     <div className={`w-full ${bgColor} h-2 rounded overflow-hidden ${className}`}>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -25,7 +25,7 @@ export default function Home() {
         <h1 className="text-3xl font-bold">
           Welcome back, {user?.firstName || 'Friend'}!
         </h1>
-        <p className="mt-2 text-gray-300 max-w-2xl">
+        <p className="mt-2 text-gray-600 dark:text-gray-300 max-w-2xl">
           Select a company from the sidebar to view question buckets and track your progress. Mark questions as solved or take notes to keep track of your preparation.
         </p>
       </div>
@@ -35,12 +35,12 @@ export default function Home() {
           <h3 className="text-lg font-medium mb-2">Recent Buckets</h3>
 
             {recent.length === 0 ? (
-              <p className="text-sm text-gray-400">No recent activity.</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">No recent activity.</p>
             ) : (
-              <ul className="space-y-2 list-disc pl-5 marker:text-gray-400">
+              <ul className="space-y-2 list-disc pl-5 marker:text-gray-600 dark:marker:text-gray-400">
                 {recent.map((r) => (
                   <li key={`${r.company}-${r.bucket}`}
-                      className="marker:text-gray-500">
+                      className="marker:text-gray-700 dark:marker:text-gray-500">
                     <Link
                       to={`/company/${encodeURIComponent(r.company)}?bucket=${encodeURIComponent(r.bucket)}`}
                       className="block w-full text-left bg-[#1545a6] hover:bg-primary focus:outline-none focus:ring-1 focus:ring-primary/50 text-white py-2 px-3 rounded-code text-sm transition-colors duration-150 hover:shadow-elevation"


### PR DESCRIPTION
## Summary
- fix color classes for text and markers on the home page
- make company select box readable in light mode
- update linear progress bar background for light mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a7e4af388321bf3914ecd01f5f8a