### PR TITLE
Update progress circle appearance

### DIFF
--- a/frontend/src/components/CircularProgress.jsx
+++ b/frontend/src/components/CircularProgress.jsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-export default function CircularProgress({ size = 80, stroke = 8, progress = 0, color = '#38bdf8', bg = '#374151' }) {
+export default function CircularProgress({
+  size = 80,
+  stroke = 8,
+  progress = 0,
+  color = 'rgb(var(--color-primary))',
+  bg = 'rgb(var(--color-gray-300))',
+}) {
   const radius = (size - stroke) / 2
   const circumference = 2 * Math.PI * radius
   const offset = circumference - (progress / 100) * circumference

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -37,7 +37,7 @@ export default function UserStats() {
     <div className="space-y-4">
       <div className="flex justify-center">
         <div className="relative">
-          <CircularProgress size={100} progress={pct} color="#38bdf8" />
+          <CircularProgress size={120} progress={pct} />
           <div className="absolute inset-0 flex flex-col items-center justify-center">
 
             <span className="text-xl font-medium">{totalSolved}/{totalQs}</span>


### PR DESCRIPTION
## Summary
- enlarge progress ring on the home page
- set circular progress colors using theme variables

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6846a9a948cc8321b115b7a6648f8ae1