### PR TITLE
Fix profile colors for light mode

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -12,7 +12,7 @@ export default function Profile() {
 
   if (!user) {
     return (
-      <div className="font-mono text-code-base text-gray-300 p-card">
+      <div className="font-mono text-code-base text-gray-700 dark:text-gray-300 p-card">
         Loading profile…
       </div>
     )
@@ -42,7 +42,7 @@ export default function Profile() {
   }
 
   return (
-    <div className="font-mono text-code-base text-gray-300 max-w-3xl mx-auto p-card space-y-6">
+    <div className="font-mono text-code-base text-gray-700 dark:text-gray-300 max-w-3xl mx-auto p-card space-y-6">
       {/* Header Section */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-code">
@@ -50,10 +50,10 @@ export default function Profile() {
             <img
               src={profilePhoto}
               alt="Profile"
-              className="h-32 w-32 rounded-full object-cover border border-gray-700"
+              className="h-32 w-32 rounded-full object-cover border border-gray-300 dark:border-gray-700"
             />
           ) : (
-            <div className="h-32 w-32 rounded-full bg-gray-700 flex items-center justify-center text-gray-300 text-5xl">
+            <div className="h-32 w-32 rounded-full bg-gray-300 dark:bg-gray-700 flex items-center justify-center text-gray-700 dark:text-gray-300 text-5xl">
               {initials}
             </div>
           )}
@@ -61,7 +61,7 @@ export default function Profile() {
             <p className="text-4xl text-primary">
               {firstName} {lastName}
             </p>
-            <p className="text-code-sm text-gray-400">{email}</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">{email}</p>
           </div>
         </div>
         <div className="flex gap-code">
@@ -92,36 +92,36 @@ export default function Profile() {
       )}
 
       {/* User Info Card */}
-      <div className="bg-surface border border-gray-800 rounded-card shadow-elevation p-card">
-        <h2 className="text-code-lg text-primary pb-2 border-b border-gray-800 mb-4">
+      <div className="bg-surface border border-gray-300 dark:border-gray-800 rounded-card shadow-elevation p-card">
+        <h2 className="text-code-lg text-primary pb-2 border-b border-gray-300 dark:border-gray-800 mb-4">
           User Information
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-code">
           <div className="space-y-2">
             <div>
-              <p className="text-code-sm text-gray-400">First Name</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">First Name</p>
               <p className="text-code-base">{firstName}</p>
             </div>
             <div>
-              <p className="text-code-sm text-gray-400">Last Name</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">Last Name</p>
               <p className="text-code-base">{lastName}</p>
             </div>
             <div>
-              <p className="text-code-sm text-gray-400">College/University</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">College/University</p>
               <p className="text-code-base">{college || '—'}</p>
             </div>
           </div>
           <div className="space-y-2">
             <div>
-              <p className="text-code-sm text-gray-400">Email</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">Email</p>
               <p className="text-code-base">{email}</p>
             </div>
             <div>
-              <p className="text-code-sm text-gray-400">Role</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">Role</p>
               <p className="text-code-base">{role || 'user'}</p>
             </div>
             <div>
-              <p className="text-code-sm text-gray-400">Account Created</p>
+              <p className="text-code-sm text-gray-600 dark:text-gray-400">Account Created</p>
               <p className="text-code-base">
                 {new Date().toLocaleDateString()}
               </p>


### PR DESCRIPTION
## Summary
- tweak profile page colors to respect light theme
- keep dark theme appearance unchanged

## Testing
- `python -m pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a9bcaf3c8321a86a671551ea8dd9