### PR TITLE
Update profile page button colors

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -67,13 +67,13 @@ export default function Profile() {
         <div className="flex gap-code">
           <Link
             to="/settings/account"
-            className="bg-primary hover:bg-primary/90 text-white font-mono text-code-sm py-2 px-4 rounded-code transition-colors"
+            className="bg-primary hover:bg-[#2a7aeb] dark:hover:bg-primary/90 text-white font-mono text-code-sm py-2 px-4 rounded-code transition-colors"
           >
             Edit Profile
           </Link>
           <button
             onClick={handleSync}
-            className="border border-primary text-primary hover:bg-primary/10 font-mono text-code-sm py-2 px-4 rounded-code transition-colors"
+            className="border border-primary text-primary hover:bg-primary/20 dark:hover:bg-primary/10 font-mono text-code-sm py-2 px-4 rounded-code transition-colors"
           >
             Sync Questions
           </button>


### PR DESCRIPTION
## Summary
- tweak Edit Profile and Sync Questions button hover colors for light mode

## Testing
- `npm test --silent --no-watch`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846ad1413a483219e9344b8287fde85