### PR TITLE
Fix light mode dropdown styling

### DIFF
--- a/frontend/src/pages/settings/ColorSettings.jsx
+++ b/frontend/src/pages/settings/ColorSettings.jsx
@@ -56,7 +56,7 @@ export default function ColorSettings() {
             <select
               value={colorMode}
               onChange={(e) => setColorMode(e.target.value)}
-              className="bg-gray-800 border border-gray-700 rounded-code px-3 py-1 text-code-base focus:outline-none focus:ring-1 focus:ring-primary"
+              className="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-code px-3 py-1 text-code-base focus:outline-none focus:ring-1 focus:ring-primary"
             >
               <option value="leet">Based on Leet difficulty</option>
               <option value="user">Based on your difficulty</option>


### PR DESCRIPTION
## Summary
- adjust ColorSettings dropdown to look correct in light mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846af6d8dc08321924667292e387f84