### PR TITLE
Sync settings sidebar color with main sidebar

### DIFF
--- a/frontend/src/components/SettingsSidebar.js
+++ b/frontend/src/components/SettingsSidebar.js
@@ -18,7 +18,8 @@ export default function SettingsSidebar({ sidebarOpen }) {
         fixed top-16 left-0 bottom-0 z-50
 
         /* Basic sidebar styling */
-        bg-surface border-r border-gray-800 shadow-elevation
+        bg-gray-200 dark:bg-surface
+        border-r border-gray-800 shadow-elevation
         overflow-y-auto sidebar-scroll
 
         transform transition-all duration-300 opacity-0


### PR DESCRIPTION
## Summary
- match the SettingsSidebar background with Sidebar in light mode

## Testing
- `pytest -q`
- `npm test --prefix frontend --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6846b11cc85c8321b7e9e66251414be3