### PR TITLE
Fix SettingsSidebar text color

### DIFF
--- a/frontend/src/components/SettingsSidebar.js
+++ b/frontend/src/components/SettingsSidebar.js
@@ -19,6 +19,7 @@ export default function SettingsSidebar({ sidebarOpen }) {
 
         /* Basic sidebar styling */
         bg-gray-200 dark:bg-surface
+        text-gray-900 dark:text-gray-100
         border-r border-gray-800 shadow-elevation
         overflow-y-auto sidebar-scroll
 


### PR DESCRIPTION
## Summary
- ensure SettingsSidebar has same text color classes as main Sidebar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846b2e7d19c8321b3ffe5d1a1673deb