### PR TITLE
Fix light mode styles for contact page

### DIFF
--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -10,25 +10,25 @@ const MailIcon = props => (
 
 export default function Contact() {
   return (
-    <div className="min-h-full flex flex-col text-gray-200 font-mono px-card py-section">
+    <div className="min-h-full flex flex-col font-mono px-card py-section text-gray-700 dark:text-gray-200">
       <div className="max-w-2xl mx-auto flex-1 space-y-6">
         <h1 className="text-3xl font-bold">Contact</h1>
-        <p className="text-gray-400">Have more company wise questions? Feel free to reach out.</p>
+        <p className="text-gray-600 dark:text-gray-400">Have more company wise questions? Feel free to reach out.</p>
         <ul className="space-y-4">
           <li className="flex items-center space-x-3">
             <MailIcon />
-            <a href="mailto:tavish.chawla.13@gmail.com" className="hover:underline text-gray-300">tavish.chawla.13@gmail.com</a>
+            <a href="mailto:tavish.chawla.13@gmail.com" className="hover:underline text-gray-700 dark:text-gray-300">tavish.chawla.13@gmail.com</a>
           </li>
           <li className="flex items-center space-x-3">
             <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/linkedin.svg" alt="LinkedIn" className="h-6 w-6 text-primary" />
-            <a href="https://www.linkedin.com/in/tavish-chawla-3b1673278/" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-300">LinkedIn</a>
+            <a href="https://www.linkedin.com/in/tavish-chawla-3b1673278/" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-700 dark:text-gray-300">LinkedIn</a>
           </li>
           <li className="flex items-center space-x-3">
             <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/instagram.svg" alt="Instagram" className="h-6 w-6 text-primary" />
-            <a href="https://www.instagram.com/tchawla827" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-300">@tchawla827</a>
+            <a href="https://www.instagram.com/tchawla827" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-700 dark:text-gray-300">@tchawla827</a>
           </li>
         </ul>
-        <p className="text-gray-400">We would love to hear your feedback and suggestions.</p>
+        <p className="text-gray-600 dark:text-gray-400">We would love to hear your feedback and suggestions.</p>
         <Link to="/" className="text-primary hover:underline">Back to Home</Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- improve readability of Contact page in light mode

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846b354586c8321b4d3a357027c4d91