### PR TITLE
Fix success message styling for light theme

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -81,7 +81,7 @@ export default function Profile() {
       </div>
 
       {message && (
-        <div className="bg-green-900/50 border border-green-800 rounded-code p-card text-code-base text-green-400">
+        <div className="bg-green-100 border border-green-300 text-green-700 rounded-code p-card text-code-base dark:bg-green-900/50 dark:border-green-800 dark:text-green-400">
           {message}
         </div>
       )}

--- a/frontend/src/pages/settings/AccountSettings.jsx
+++ b/frontend/src/pages/settings/AccountSettings.jsx
@@ -215,8 +215,8 @@ export default function AccountSettings() {
         </button>
 
         {message && (
-          <div className="mt-4 p-3 bg-green-900/50 border border-green-800 rounded-code">
-            <p className="text-green-400 text-code-sm font-mono">{message}</p>
+          <div className="mt-4 p-3 bg-green-100 border border-green-300 text-green-700 rounded-code dark:bg-green-900/50 dark:border-green-800 dark:text-green-400">
+            <p className="text-code-sm font-mono">{message}</p>
           </div>
         )}
 

--- a/frontend/src/pages/settings/ColorSettings.jsx
+++ b/frontend/src/pages/settings/ColorSettings.jsx
@@ -117,7 +117,7 @@ export default function ColorSettings() {
       </div>
 
       {message && (
-        <div className="bg-green-900/50 border border-green-800 rounded-code p-card text-code-base text-green-400">
+        <div className="bg-green-100 border border-green-300 text-green-700 rounded-code p-card text-code-base dark:bg-green-900/50 dark:border-green-800 dark:text-green-400">
           {message}
         </div>
       )}

--- a/frontend/src/pages/settings/LeetCodeSettings.jsx
+++ b/frontend/src/pages/settings/LeetCodeSettings.jsx
@@ -108,7 +108,7 @@ export default function LeetCodeSettings() {
       </div>
 
       {message && (
-        <div className="bg-green-900/50 border border-green-800 rounded-code p-card text-code-base text-green-400">
+        <div className="bg-green-100 border border-green-300 text-green-700 rounded-code p-card text-code-base dark:bg-green-900/50 dark:border-green-800 dark:text-green-400">
           {message}
         </div>
       )}


### PR DESCRIPTION
## Summary
- tweak success message styles on settings and profile pages so light theme looks correct

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d0aa6cbc832191babaaa5e8fab7d