### PR TITLE
Add consistent loading spinner across pages

### DIFF
--- a/frontend/src/components/CompanyProgress.jsx
+++ b/frontend/src/components/CompanyProgress.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import Loading from './Loading'
 
 /**
  * Expects props.data to be an array of:
@@ -11,11 +12,7 @@ import PropTypes from 'prop-types'
  */
 export default function CompanyProgress({ data, loading }) {
   if (loading) {
-    return (
-      <div className="font-mono text-code-sm text-gray-500 italic">
-        Loading progress…
-      </div>
-    )
+    return <Loading message="Loading progress…" />
   }
 
   // Filter out any bucket with total === 0

--- a/frontend/src/components/CompanyStats.jsx
+++ b/frontend/src/components/CompanyStats.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { fetchUserStats } from '../api'
 import LinearProgress from './LinearProgress'
+import Loading from './Loading'
 
 export default function CompanyStats() {
   const [companies, setCompanies] = useState([])
@@ -36,9 +37,7 @@ export default function CompanyStats() {
   }, [companies, sortBy])
 
   if (loading) {
-    return (
-      <div className="font-mono text-code-sm text-gray-500 italic">Loading company stats…</div>
-    )
+    return <Loading message="Loading company stats…" />
   }
 
   if (!companies.length) {

--- a/frontend/src/components/Loading.jsx
+++ b/frontend/src/components/Loading.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import Spinner from './Spinner'
+
+export default function Loading({ message = 'Loading…', className = '' }) {
+  return (
+    <div className={`flex flex-col items-center justify-center ${className}`}>
+      <Spinner size={32} className="mb-2" />
+      {message && (
+        <p className="text-gray-500 dark:text-gray-400 font-mono text-code-sm">
+          {message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import api from '../api';
+import Loading from './Loading';
 
 export default function PrivateRoute({ children }) {
   const [authChecked, setAuthChecked] = useState(false);
@@ -15,7 +16,7 @@ export default function PrivateRoute({ children }) {
   }, []);
 
   if (!authChecked) {
-    return <div>Loading…</div>;
+    return <Loading />;
   }
   if (!isLoggedIn) {
     return <Navigate to="/login" replace />;

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import CircularProgress from './CircularProgress'
 import { fetchUserStats } from '../api'
+import Loading from './Loading'
 
 export default function UserStats() {
   const [stats, setStats] = useState(null)
@@ -14,9 +15,7 @@ export default function UserStats() {
   }, [])
 
   if (loading) {
-    return (
-      <div className="font-mono text-code-sm text-gray-500 italic">Loading stats…</div>
-    )
+    return <Loading message="Loading stats…" />
   }
 
   if (!stats) {

--- a/frontend/src/pages/CompanyPage.js
+++ b/frontend/src/pages/CompanyPage.js
@@ -6,6 +6,7 @@ import BucketsTabs from '../components/BucketsTabs'
 import QuestionsTable from '../components/QuestionsTable'
 import TopicsDashboard from '../components/TopicsDashboard'
 import CompanyProgress from '../components/CompanyProgress'
+import Loading from '../components/Loading'
 import { fetchCompanyProgress } from '../api'
 
 const BUCKET_ORDER = [
@@ -179,7 +180,9 @@ export default function CompanyPage() {
       </div>
 
       {bucketsLoading ? (
-        <div className="text-sm text-gray-500 italic">Loading buckets...</div>
+        <div className="py-4">
+          <Loading message="Loading buckets…" />
+        </div>
       ) : buckets.length > 0 ? (
         <BucketsTabs
           buckets={buckets}
@@ -227,7 +230,9 @@ export default function CompanyPage() {
               className={`transition-opacity duration-300 ${showAnalytics ? 'opacity-100' : 'opacity-0 pointer-events-none absolute inset-0'}`}
             >
               {loadingTopics ? (
-                <div className="text-sm text-gray-500 italic">Loading analytics...</div>
+                <div className="py-4">
+                  <Loading message="Loading analytics…" />
+                </div>
               ) : (
                 <div className="space-y-8">
                   {/* ── 1) CompanyProgress is now only shown here ─────────────── */}

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { Link } from 'react-router-dom'
 import { extractErrorMessage } from '../utils/error'
+import Loading from '../components/Loading'
 
 export default function Profile() {
   const { user, syncBackground } = useAuth()
@@ -11,11 +12,7 @@ export default function Profile() {
   const [error, setError] = useState('')
 
   if (!user) {
-    return (
-      <div className="font-mono text-code-base text-gray-700 dark:text-gray-300 p-card">
-        Loading profile…
-      </div>
-    )
+    return <Loading message="Loading profile…" />
   }
 
   const {

--- a/frontend/src/pages/settings/AccountSettings.jsx
+++ b/frontend/src/pages/settings/AccountSettings.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../context/AuthContext'
 import { Link } from 'react-router-dom'
 import UniversityAutocomplete from '../../components/UniversityAutocomplete.jsx'
 import { extractErrorMessage } from '../../utils/error'
+import Loading from '../../components/Loading'
 
 export default function AccountSettings() {
   const {
@@ -131,8 +132,8 @@ export default function AccountSettings() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="w-12 h-12 border-4 border-gray-600 dark:border-gray-300 border-t-primary rounded-full animate-spin"></div>
+      <div className="py-10">
+        <Loading />
       </div>
     )
   }

--- a/frontend/src/pages/settings/LeetCodeSettings.jsx
+++ b/frontend/src/pages/settings/LeetCodeSettings.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { useAuth } from '../../context/AuthContext'
 import api from '../../api'
 import { extractErrorMessage } from '../../utils/error'
+import Loading from '../../components/Loading'
 
 export default function LeetCodeSettings() {
   const { user, syncBackground } = useAuth()
@@ -53,11 +54,7 @@ export default function LeetCodeSettings() {
   }
 
   if (loading) {
-    return (
-      <div className="font-mono text-code-base text-gray-700 dark:text-gray-300 p-card">
-        Loading LeetCode settings…
-      </div>
-    )
+    return <Loading message="Loading LeetCode settings…" />
   }
 
   return (


### PR DESCRIPTION
## Summary
- introduce `Loading` component for spinner w/ optional message
- use new spinner in CompanyStats, CompanyProgress, UserStats
- update PrivateRoute and Profile page with new Loading component
- show spinner while buckets or analytics load on CompanyPage
- show spinner in account & LeetCode settings pages

## Testing
- `pytest -q`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6846d101151483219715ca39c20596be