### PR TITLE
Fix total question count in user stats

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1214,14 +1214,9 @@ def user_stats():
     company_stats = list(CQ.aggregate(company_pipeline))
 
 
-    # Count unique question slugs across all companies to avoid duplicates
-    qids = CQ.distinct('question_id')
-    links = [q.get('link', '') for q in QUEST.find({'_id': {'$in': qids}}, {'link': 1})]
-    slugs = {
-        link.rstrip('/').split('/')[-1].split('?')[0].lower()
-        for link in links if link
-    }
-    total_questions = len(slugs)
+    # Count unique canonical questions directly from the questions collection
+    # to avoid double counting company-specific duplicates.
+    total_questions = QUEST.count_documents({})
 
 
     data = {


### PR DESCRIPTION
## Summary
- compute total number of questions from the canonical `questions` collection

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846d532eb1c83219e870a5027af7f59