### PR TITLE
Increase landing page logo size

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -67,7 +67,7 @@ export default function Landing() {
       <footer className="border-t border-gray-800 py-8 px-card">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between text-sm text-gray-400">
           <div className="flex items-center space-x-2 mb-4 md:mb-0">
-            <img src={logo} alt="LeetEase logo" className="h-14 w-6" />
+            <img src={logo} alt="LeetEase logo" className="h-16 w-auto" />
             <span>Leet<span className="text-primary">Ease</span></span>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- enlarge the logo in the landing page footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e8bf87bc83218c2c3382263efc35