### PR TITLE
Add shimmer animation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -143,3 +143,18 @@ body {
 .main-screen-bg {
   @apply bg-background bg-dev-grid bg-repeat bg-[length:100px_100px];
 }
+
+/* Shimmer animation for loading effects */
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.animate-shimmer {
+  animation: shimmer 2s infinite;
+}
+

--- a/frontend/src/components/CompanyProgress.jsx
+++ b/frontend/src/components/CompanyProgress.jsx
@@ -44,11 +44,27 @@ export default function CompanyProgress({ data, loading }) {
                   {solved} / {total} (<span className="text-primary">{pct}%</span>)
                 </span>
               </div>
-              <div className="w-full bg-gray-800 h-2 rounded overflow-hidden">
+              <div className="w-full bg-gray-800 h-2 rounded-full overflow-hidden">
                 <div
-                  className="bg-green-500 h-full transition-all duration-300"
+                  className={`
+                    h-full rounded-full transition-all duration-1000 ease-out
+                    relative overflow-hidden
+                    ${pct === 100
+                      ? 'bg-gradient-to-r from-success via-success/80 to-success'
+                      : pct >= 75
+                        ? 'bg-gradient-to-r from-info via-info/80 to-info'
+                        : pct >= 50
+                          ? 'bg-gradient-to-r from-warning via-warning/80 to-warning'
+                          : 'bg-gradient-to-r from-primary via-primary/80 to-primary'}
+                  `}
                   style={{ width: `${pct}%` }}
-                />
+                  role="progressbar"
+                  aria-valuenow={pct}
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                >
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent animate-shimmer" />
+                </div>
               </div>
             </li>
           )


### PR DESCRIPTION
## Summary
- add shimmer animation keyframes to global CSS
- redesign CompanyProgress progress bars with gradient fill and shimmer effect

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_session')*


------
https://chatgpt.com/codex/tasks/task_e_6846e9e4390c83219d5ccc063a4a779e