### PR TITLE
Add user stats hook for caching

### DIFF
--- a/frontend/src/components/CompanyStats.jsx
+++ b/frontend/src/components/CompanyStats.jsx
@@ -1,21 +1,14 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { fetchUserStats } from '../api'
 import LinearProgress from './LinearProgress'
 import Loading from './Loading'
+import useUserStats from '../context/useUserStats'
 
 export default function CompanyStats() {
-  const [companies, setCompanies] = useState([])
-  const [loading, setLoading] = useState(true)
+  const { stats, loading } = useUserStats()
+  const companies = stats?.companies || []
   const [sortBy, setSortBy] = useState('name')
   const [filter, setFilter] = useState('')
-
-  useEffect(() => {
-    fetchUserStats()
-      .then(res => setCompanies(res.data.companies || []))
-      .catch(() => setCompanies([]))
-      .finally(() => setLoading(false))
-  }, [])
 
   const sorted = useMemo(() => {
     const list = [...companies]

--- a/frontend/src/components/UserStats.jsx
+++ b/frontend/src/components/UserStats.jsx
@@ -1,18 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import CircularProgress from './CircularProgress'
-import { fetchUserStats } from '../api'
 import Loading from './Loading'
+import useUserStats from '../context/useUserStats'
 
 export default function UserStats() {
-  const [stats, setStats] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    fetchUserStats()
-      .then(res => setStats(res.data))
-      .catch(() => setStats(null))
-      .finally(() => setLoading(false))
-  }, [])
+  const { stats, loading } = useUserStats()
 
   if (loading) {
     return <Loading message="Loading stats…" />

--- a/frontend/src/context/useUserStats.js
+++ b/frontend/src/context/useUserStats.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react'
+import { fetchUserStats } from '../api'
+
+let cached = null
+let inflight = null
+
+export default function useUserStats() {
+  const [stats, setStats] = useState(cached)
+  const [loading, setLoading] = useState(!cached)
+
+  useEffect(() => {
+    if (cached) return
+
+    if (!inflight) {
+      inflight = fetchUserStats()
+        .then(res => {
+          cached = res.data
+          setStats(cached)
+        })
+        .catch(() => {
+          cached = null
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+    } else {
+      inflight.finally(() => {
+        setStats(cached)
+        setLoading(false)
+      })
+    }
+  }, [])
+
+  return { stats, loading }
+}


### PR DESCRIPTION
## Summary
- add `useUserStats` shared hook
- refactor `UserStats` and `CompanyStats` components to use the hook

## Testing
- `pytest -q`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846eaea295c83219942e19724291f51