### PR TITLE
Adjust Recent Buckets limit

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1092,7 +1092,7 @@ def company_progress(company):
 def recent_buckets():
     """Return most recently updated company buckets for the current user."""
     uid   = get_jwt_identity()
-    limit = int(request.args.get('limit', 4))
+    limit = int(request.args.get('limit', 8))
 
     pipeline = [
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -111,7 +111,7 @@ export function fetchCompanyProgress(companyName) {
   return api.get(path);
 }
 
-export function fetchRecentBuckets(limit = 4) {
+export function fetchRecentBuckets(limit = 8) {
   return api.get(`/api/recent-buckets?limit=${limit}`);
 }
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -13,7 +13,7 @@ export default function Home() {
   const [recent, setRecent] = useState([])
 
   useEffect(() => {
-    fetchRecentBuckets()
+    fetchRecentBuckets(8)
       .then(res => setRecent(res.data.data || []))
       .catch(() => setRecent([]))
   }, [])


### PR DESCRIPTION
## Summary
- display more recent buckets on the home page
- bump the API default `recent-buckets` limit to 8

## Testing
- `pytest -q`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd318b408321856c3d5a7bf3b8dd