### PR TITLE
Fix theme switch flicker

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,6 +16,13 @@ body {
   color: rgb(var(--color-text));
 }
 
+/* Smooth transitions for background and text colors */
+.theme-transition,
+.theme-transition * {
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
 /* Custom scrollbar styling for sidebar components */
 .sidebar-scroll {
   scrollbar-width: thin;

--- a/frontend/src/context/ThemeContext.js
+++ b/frontend/src/context/ThemeContext.js
@@ -1,20 +1,20 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useState,
+} from 'react';
 
 const ThemeContext = createContext();
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState('dark');
-
-  // Load saved preference on mount
-  useEffect(() => {
+  const [theme, setTheme] = useState(() => {
     const stored = localStorage.getItem('theme');
-    if (stored === 'light' || stored === 'dark') {
-      setTheme(stored);
-    }
-  }, []);
+    return stored === 'light' || stored === 'dark' ? stored : 'dark';
+  });
 
-  // Apply class and persist preference
-  useEffect(() => {
+  // Apply class and persist preference synchronously
+  useLayoutEffect(() => {
     const root = document.documentElement;
     if (theme === 'dark') {
       root.classList.add('dark');
@@ -24,8 +24,14 @@ export function ThemeProvider({ children }) {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  const toggleTheme = () =>
+  const toggleTheme = () => {
+    const root = document.documentElement;
+    root.classList.add('theme-transition');
+    setTimeout(() => {
+      root.classList.remove('theme-transition');
+    }, 300);
     setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>


### PR DESCRIPTION
## Summary
- ensure theme class toggles before paint
- read theme preference when initializing state
- add `theme-transition` class for smoother transitions

## Testing
- `pip install -r backend/requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847013a6b3883218d5efd4f214f8ce3