### PR TITLE
Fix theme switch timing

### DIFF
--- a/frontend/src/context/ThemeContext.js
+++ b/frontend/src/context/ThemeContext.js
@@ -27,10 +27,20 @@ export function ThemeProvider({ children }) {
   const toggleTheme = () => {
     const root = document.documentElement;
     root.classList.add('theme-transition');
+
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+
+    if (newTheme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
     setTimeout(() => {
       root.classList.remove('theme-transition');
     }, 300);
-    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+    setTheme(newTheme);
   };
 
   return (


### PR DESCRIPTION
## Summary
- toggle `dark` class immediately when switching theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847051a750483218797f4ec14922c8a