### PR TITLE
Refresh stats on home page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -66,7 +66,8 @@ USERS     = db.users
 
 # Cache for per-user statistics (simple in-memory)
 STATS_CACHE = {}
-STATS_TTL_SECONDS = 60
+# Disable caching so stats refresh on every request
+STATS_TTL_SECONDS = 0
 
 # ─── Error Handlers ───────────────────────────────────────────────────────
 @app.errorhandler(HTTPException)


### PR DESCRIPTION
## Summary
- disable server-side stats caching
- fetch user stats on every mount so home page shows fresh data

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847065922c88321aba455fd1d4c14c2