### PR TITLE
Improve theme transition

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,6 +16,13 @@ body {
   color: rgb(var(--color-text));
 }
 
+/* Smooth color scheme transitions */
+.color-transition,
+.color-transition * {
+  transition: background-color 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease;
+}
+
 /* Custom scrollbar styling for sidebar components */
 .sidebar-scroll {
   scrollbar-width: thin;

--- a/frontend/src/context/ThemeContext.js
+++ b/frontend/src/context/ThemeContext.js
@@ -1,27 +1,31 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useLayoutEffect, useState } from 'react';
 
 const ThemeContext = createContext();
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState('dark');
-
-  // Load saved preference on mount
-  useEffect(() => {
+  const [theme, setTheme] = useState(() => {
     const stored = localStorage.getItem('theme');
     if (stored === 'light' || stored === 'dark') {
-      setTheme(stored);
+      return stored;
     }
-  }, []);
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  });
 
-  // Apply class and persist preference
-  useEffect(() => {
+  // Apply class and persist preference with a smooth transition
+  useLayoutEffect(() => {
     const root = document.documentElement;
+    root.classList.add('color-transition');
+    const timer = setTimeout(() => root.classList.remove('color-transition'), 300);
+
     if (theme === 'dark') {
       root.classList.add('dark');
     } else {
       root.classList.remove('dark');
     }
     localStorage.setItem('theme', theme);
+    return () => clearTimeout(timer);
   }, [theme]);
 
   const toggleTheme = () =>


### PR DESCRIPTION
## Summary
- prevent initial flicker and apply theme preference immediately
- add global CSS transitions for color scheme changes
- apply temporary transition class whenever the theme toggles

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478b51088c8321b07c043f1429d7a6