### PR TITLE
Fix landing page colors for light mode

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -112,18 +112,35 @@ body {
   background: linear-gradient(
     135deg,
     rgba(31, 111, 235, 0.15) 0%,
-    rgba(13, 17, 23, 1) 100%
+    rgb(var(--color-surface)) 100%
+  );
+}
+
+.dark .hero-gradient {
+  background: linear-gradient(
+    135deg,
+    rgba(31, 111, 235, 0.15) 0%,
+    #0d1117 100%
   );
 }
 
 .dashboard-placeholder {
   background: linear-gradient(
     135deg,
+    rgb(var(--color-background)) 0%,
+    rgb(var(--color-surface)) 100%
+  );
+  border: 1px solid rgb(var(--color-gray-300));
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.5);
+}
+
+.dark .dashboard-placeholder {
+  background: linear-gradient(
+    135deg,
     #0d1117 0%,
     #161b22 100%
   );
   border: 1px solid #363b46;
-  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.5);
 }
 
 .feature-bullet::before {

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -20,7 +20,7 @@ export default function Landing() {
     return () => observer.disconnect()
   }, [])
   return (
-    <div className="min-h-full flex flex-col text-gray-200 font-mono">
+    <div className="min-h-full flex flex-col font-mono text-gray-900 dark:text-gray-200">
 
       {/* Hero */}
       <section className="hero-gradient flex flex-col items-center justify-center text-center py-section px-card flex-grow reveal opacity-0 translate-y-4">
@@ -64,7 +64,7 @@ export default function Landing() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-gray-800 py-8 px-card">
+      <footer className="border-t border-gray-300 dark:border-gray-800 py-8 px-card">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between text-sm text-gray-400">
           <div className="flex items-center space-x-2 mb-4 md:mb-0">
             <img src={logo} alt="LeetEase logo" className="h-16 w-auto" />


### PR DESCRIPTION
## Summary
- polish landing page styles for light mode
- keep dark theme behavior intact

## Testing
- `npm test -- -w 0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478eb7fcfc8321a48ae95a836eab21