### PR TITLE
Remove open source footer text

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -70,9 +70,7 @@ export default function Landing() {
             <img src={logo} alt="LeetEase logo" className="h-16 w-auto" />
           </div>
           <div>
-            &copy; 2023 LeetEase. Open source on
-            <a href="https://github.com/leetease" className="text-primary hover:underline ml-1">GitHub</a>.
-            <Link to="/contact" className="text-primary hover:underline ml-2">Contact</Link>
+            <Link to="/contact" className="text-primary hover:underline">Contact</Link>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- remove the © 2023 LeetEase "Open source on GitHub" footer text from landing page

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847926767f88321b2657d4a3a1aa769