### PR TITLE
Add Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ If either variable is missing, the application will raise a `RuntimeError` at st
 Define them in your `.env` file or export them in your deployment environment.
 
 
+## Docker and Docker Compose
+
+The project ships with a `docker-compose.yml` that starts both MongoDB and the
+Flask application. Copy `backend/.env.example` to `backend/.env` and adjust the
+values as needed. Docker Compose will read this file when creating the
+`app` service.
+
+Build and run the containers with:
+
+```bash
+docker compose up --build
+```
+
+The backend (and bundled React frontend) will be available on
+`http://localhost:5000`. MongoDB runs inside the Compose network and is not
+exposed by default.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,8 @@ services:
     build: .
     ports:
       - "5000:5000"
-    environment:
-      - MONGODB_URI=mongodb://mongo:27017/leetease
-      - SECRET_KEY=change-me
-      - JWT_SECRET_KEY=change-me
+    env_file:
+      - backend/.env
     depends_on:
       - mongo
 volumes:


### PR DESCRIPTION
## Summary
- update `docker-compose.yml` to load env vars from `backend/.env`
- document Docker usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847967a47708321b477a2e34739549e