### PR TITLE
Fix Flask host binding for Docker

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1291,4 +1291,7 @@ if __name__ == '__main__':
     # _startup_sync()
     debug_env = os.getenv('FLASK_DEBUG', '').lower()
     debug = debug_env in ('1', 'true', 'yes')
-    app.run(debug=debug)
+
+    host = os.getenv('FLASK_RUN_HOST', '0.0.0.0')
+    port = int(os.getenv('FLASK_RUN_PORT', 5000))
+    app.run(host=host, port=port, debug=debug)


### PR DESCRIPTION
## Summary
- update Flask startup code to read host and port from the environment so Docker can reach the server

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847a379c4088321961627a861667902