### PR TITLE
Fix extension import

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,7 +31,11 @@ try:
 except ImportError:  # Allow running as a script
     import config
     from config import get_db
-from extensions import jwt, sess, bcrypt, mail, csrf
+
+try:
+    from .extensions import jwt, sess, bcrypt, mail, csrf
+except ImportError:  # Fallback for script execution
+    from extensions import jwt, sess, bcrypt, mail, csrf
 from flask_cors import CORS
 from flask_wtf.csrf import generate_csrf
 import bleach


### PR DESCRIPTION
## Summary
- fix import of Flask extensions to support module execution

## Testing
- `pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847d8e9d4f88321b5e4c0c05a79bade