### PR TITLE
Add APP_SERVER toggle for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ dependencies for you.
    cp backend/.env.example backend/.env
    ```
 
-2. Build and start the containers:
+2. Build and start the containers. By default the backend runs with Gunicorn.
+   Set `APP_SERVER=flask` to use Flask's built-in server instead.
 
    ```bash
-   docker compose up --build
+   docker compose up --build            # Gunicorn
+   # APP_SERVER=flask docker compose up # Flask dev server
    ```
 
 The backend and built React frontend will be available on

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,3 +27,8 @@ FRONTEND_URL="http://localhost:3000"
 
 # ── CORS allowed origins (comma separated) ─────────────────────────────
 CORS_ORIGINS="http://localhost:3000"
+
+# ── Server mode ──────────────────────────────────────────────────────────
+# Use 'flask' to run the development server via Docker Compose
+# or leave as 'gunicorn' for production.
+APP_SERVER="gunicorn"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,18 @@ services:
       - mongo-data:/data/db
   app:
     build: .
+    environment:
+      APP_SERVER: ${APP_SERVER:-gunicorn}
     ports:
       - "5000:5000"
     env_file:
       - backend/.env
+    command: >
+      sh -c 'if [ "$APP_SERVER" = "flask" ]; then \
+                flask --app backend.app run --host=0.0.0.0 --port 5000; \
+              else \
+                gunicorn -b 0.0.0.0:5000 -w ${WORKERS:-1} backend.app:app; \
+              fi'
     depends_on:
       - mongo
 volumes:


### PR DESCRIPTION
## Summary
- support switching between Gunicorn and the Flask dev server in Docker Compose via `APP_SERVER`
- document how to use `APP_SERVER` for local Docker runs
- expose `APP_SERVER` variable in example `.env`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e0e14a888321a8c8a4cd26e42cf9