### PR TITLE
Improve DB efficiency

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -25,6 +25,17 @@ _client = MongoClient(MONGODB_URI)
 def get_db():
     return _client.get_default_database()
 
+def ensure_indexes(db):
+    """Create indexes used across the application."""
+    db.questions.create_index('link', unique=True)
+    db.companies.create_index('name', unique=True)
+    db.company_questions.create_index(
+        [('company_id', 1), ('bucket', 1), ('question_id', 1)], unique=True
+    )
+    db.company_questions.create_index('question_id')
+    db.user_meta.create_index([('user_id', 1), ('question_id', 1)])
+    db.user_meta.create_index([('user_id', 1), ('company_id', 1), ('bucket', 1)])
+
 # ————————————————
 # Flask-JWT-Extended
 # ————————————————


### PR DESCRIPTION
## Summary
- create a helper to ensure MongoDB indexes
- call index setup optionally at startup
- batch metadata updates with `bulk_write`
- fetch question metadata in fewer queries
- return updated document with a single round trip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481d688100832187dc76afdd923090