### PR TITLE
Fix profile photo persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,6 @@ dependencies for you.
 
 The backend and built React frontend will be available on
 `http://localhost:5000`. MongoDB runs inside the Compose network and persists
-data in the `mongo-data` volume.
+data in the `mongo-data` volume. Profile photos uploaded by users are stored in
+the `profile-photos` volume so they survive container restarts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - "5000:5000"
     env_file:
       - backend/.env
+    volumes:
+      - profile-photos:/app/backend/uploads/profile_photos
     command: >
       sh -c 'if [ "$APP_SERVER" = "flask" ]; then \
                 flask --app backend.app run --host=0.0.0.0 --port 5000; \
@@ -23,3 +25,4 @@ services:
       - mongo
 volumes:
   mongo-data:
+  profile-photos:


### PR DESCRIPTION
## Summary
- persist user-uploaded profile photos by adding a `profile-photos` Docker volume
- document the new volume in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481dc80dbc832193dac76dc8c9f16c