### PR TITLE
Make profile photo path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,15 @@ The backend and built React frontend will be available on
 data in the `mongo-data` volume. Profile photos uploaded by users are stored in
 the `profile-photos` volume so they survive container restarts.
 
+## Deploying on Render
+
+When deploying to [Render](https://render.com), the container's filesystem is
+ephemeral. Attach a persistent disk (typically mounted at `/var/data`) and set
+the `PROFILE_PHOTOS_DIR` environment variable to a folder on that disk, e.g.:
+
+```bash
+PROFILE_PHOTOS_DIR=/var/data/profile-photos
+```
+
+This ensures uploaded profile photos remain available across deploys.
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,3 +32,8 @@ CORS_ORIGINS="http://localhost:3000"
 # Use 'flask' to run the development server via Docker Compose
 # or leave as 'gunicorn' for production.
 APP_SERVER="gunicorn"
+
+# ── Profile photo storage path ──────────────────────────────────────────
+# Override to store uploaded photos on a persistent volume (e.g. /var/data
+# when deploying to Render)
+PROFILE_PHOTOS_DIR=""

--- a/backend/config.py
+++ b/backend/config.py
@@ -85,8 +85,13 @@ CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000")
 # Base directory of the project
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-# Directory where profile photos will be stored
-UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads", "profile_photos")
+# Directory where profile photos will be stored. This can be overridden
+# via the PROFILE_PHOTOS_DIR environment variable to support providers
+# like Render that mount persistent disks at a specific path.
+UPLOAD_FOLDER = os.getenv(
+    "PROFILE_PHOTOS_DIR",
+    os.path.join(BASE_DIR, "uploads", "profile_photos"),
+)
 # Maximum file size (in bytes). E.g., 2 MB max.
 MAX_CONTENT_LENGTH = 2 * 1024 * 1024
 


### PR DESCRIPTION
## Summary
- allow overriding profile photo upload path via PROFILE_PHOTOS_DIR
- document Render deployment step with persistent disk
- expose PROFILE_PHOTOS_DIR in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684823dff4fc83219c2454cdaa2fd490