### PR TITLE
Store profile photos in MongoDB GridFS

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -82,11 +82,6 @@ CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000")
 # ————————————————
 # File Uploads (Profile Photos)
 # ————————————————
-# Base directory of the project
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-
-# Directory where profile photos will be stored
-UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads", "profile_photos")
 # Maximum file size (in bytes). E.g., 2 MB max.
 MAX_CONTENT_LENGTH = 2 * 1024 * 1024
 


### PR DESCRIPTION
## Summary
- stop using upload directories in config
- integrate GridFS and helper to serialize user info
- store profile photos in GridFS and serve via `/api/profile/photo/<file_id>`
- fix missing `send_from_directory` import

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68482994d8348321a10f0170ec3d7953