### PR TITLE
Implement Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The backend expects certain security keys to be set before it starts. Copy
 - `SECRET_KEY`: Flask's secret key used for sessions.
 - `MONGODB_URI`: Mongo connection string.
 - `JWT_SECRET_KEY`: key used to sign JWT tokens.
+- `GOOGLE_CLIENT_ID`: OAuth client ID for Google sign-in.
 
 If either variable is missing, the application will raise a `RuntimeError` at startup.
 Define them in your `.env` file or export them in your deployment environment.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,9 @@ LEETCODE_SESSION="<your-leetcode-session-token>"
 # ── Frontend URL (CORS / OAuth callbacks) ──────────────────────────────
 FRONTEND_URL="http://localhost:3000"
 
+# Google Sign-In
+GOOGLE_CLIENT_ID="<your-google-client-id>"
+
 
 # ── CORS allowed origins (comma separated) ─────────────────────────────
 CORS_ORIGINS="http://localhost:3000"

--- a/backend/config.py
+++ b/backend/config.py
@@ -79,6 +79,9 @@ MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "noreply@example.com")
 FRONTEND_URL = os.getenv("FRONTEND_URL")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000")
 
+# Google OAuth
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+
 # ————————————————
 # File Uploads (Profile Photos)
 # ————————————————

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Ensure env vars before importing app
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('MONGODB_URI', 'mongodb://localhost:27017/test')
+os.environ.setdefault('JWT_SECRET_KEY', 'testjwt')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'cid123')
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+import app as app_module
+from app import app
+import requests
+
+class GoogleAuthTests(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        # Disable CSRF for testing
+        app_module.csrf.exempt(app_module.google_login)
+        
+    def test_invalid_token(self):
+        with patch('app.requests.get', side_effect=requests.RequestException("fail")):
+            self.client.set_cookie('csrf_token', 't', domain='localhost')
+            resp = self.client.post('/auth/google', json={'idToken': 'bad'}, headers={'X-CSRFToken': 't'})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_create_user(self):
+        response_obj = MagicMock()
+        response_obj.raise_for_status.return_value = None
+        response_obj.json.return_value = {
+            'aud': 'cid123',
+            'email': 'u@example.com',
+            'given_name': 'User',
+            'family_name': 'Test'
+        }
+        with patch('app.requests.get', return_value=response_obj), \
+             patch.object(app_module, 'USERS') as mock_users:
+            mock_users.find_one.return_value = None
+            mock_users.insert_one.return_value.inserted_id = '1'
+            self.client.set_cookie('csrf_token', 't', domain='localhost')
+            resp = self.client.post('/auth/google', json={'idToken': 'good'}, headers={'X-CSRFToken': 't'})
+            self.assertEqual(resp.status_code, 200)
+            mock_users.insert_one.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `/auth/google` endpoint to allow signing in with Google
- store Google OAuth client ID in config
- document new GOOGLE_CLIENT_ID variable
- add example variable to `.env.example`
- add unit tests for Google login

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6848ec04664c832198fef8182d5df236