### PR TITLE
Update env docs for local Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,21 @@ Copy `frontend/.env.example` to `frontend/.env` and set these as needed when run
 Docker provides an isolated environment that installs all Python and Node.js
 dependencies for you.
 
-1. Copy the example environment file:
+1. Copy the example environment file for the backend **and** frontend:
 
    ```bash
    cp backend/.env.example backend/.env
+   cp frontend/.env.example frontend/.env
+   ```
+
+   When running locally over HTTP make sure the following values are set:
+
+   ```bash
+   # allow cookies over HTTP
+   echo "JWT_COOKIE_SECURE=False" >> backend/.env
+
+   # point the React app to the local API
+   sed -i "s|REACT_APP_API_URL=.*|REACT_APP_API_URL=http://localhost:5000|" frontend/.env
    ```
 
 2. Build and start the containers. By default the backend runs with Gunicorn.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,7 @@ MONGODB_URI="mongodb+srv://<username>:<password>@<cluster-url>/<database>?retryW
 SECRET_KEY="<your-secret-key>"
 JWT_SECRET_KEY="<your-jwt-secret-key>"
 JWT_ACCESS_TOKEN_EXPIRES=3600      # seconds
+JWT_COOKIE_SECURE=False            # allow cookies over HTTP in local testing
 
 # ── Server-side session storage ───────────────────────────────────────
 SESSION_FILE_DIR="./.flask_session/"

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,3 @@
 REACT_APP_GOOGLE_CLIENT_ID=150652421588-shdpr907n09iq8stvjgvn453dm8s9b93.apps.googleusercontent.com
-REACT_APP_API_URL=https://leetease.onrender.com
+REACT_APP_API_URL=http://localhost:5000
 


### PR DESCRIPTION
## Summary
- explain how to set up `.env` files for Docker
- allow HTTP cookies in backend example
- default frontend API URL to localhost

## Testing
- `pip install flask requests pymongo python-dotenv`
- `pip install pandas==2.2.2 numpy==1.26.4`
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f8b5092c8321bb39115e4195b863