### PR TITLE
Fix home stats refresh

### DIFF
--- a/frontend/src/context/useUserStats.js
+++ b/frontend/src/context/useUserStats.js
@@ -1,33 +1,32 @@
 import { useState, useEffect } from 'react'
 import { fetchUserStats } from '../api'
 
-let cached = null
-let inflight = null
-
 export default function useUserStats() {
-  const [stats, setStats] = useState(cached)
-  const [loading, setLoading] = useState(!cached)
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    if (cached) return
+    let cancelled = false
 
-    if (!inflight) {
-      inflight = fetchUserStats()
-        .then(res => {
-          cached = res.data
-          setStats(cached)
-        })
-        .catch(() => {
-          cached = null
-        })
-        .finally(() => {
-          setLoading(false)
-        })
-    } else {
-      inflight.finally(() => {
-        setStats(cached)
-        setLoading(false)
+    fetchUserStats()
+      .then(res => {
+        if (!cancelled) {
+          setStats(res.data)
+        }
       })
+      .catch(() => {
+        if (!cancelled) {
+          setStats(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- refresh stats data whenever home page mounts

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684900f2a0bc83218eb9f6faf3274c11