### PR TITLE
Update landing page image

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import logo from '../assets/logo.svg'
+import placeholderImage from '../assets/placeholder_image.png'
 
 export default function Landing() {
   useEffect(() => {
@@ -51,7 +52,11 @@ export default function Landing() {
             </ul>
           </div>
           <div className="rounded-xl p-2 bg-white border border-gray-300 shadow-elevation dark:dashboard-placeholder">
-            <div className="bg-surface rounded-lg h-64" />
+            <img
+              src={placeholderImage}
+              alt="App preview"
+              className="bg-surface rounded-lg h-64 w-full object-cover"
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- display placeholder image on the landing page

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490148285883219368623e86a25817