### PR TITLE
Fix landing page placeholder for theme

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -2,8 +2,12 @@ import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import logo from '../assets/logo.svg'
 import placeholderImage from '../assets/placeholder_image.png'
+import placeholderImageLight from '../assets/placeholder_image_light.png'
+import { useTheme } from '../context/ThemeContext'
 
 export default function Landing() {
+  const { theme } = useTheme()
+
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
@@ -53,7 +57,7 @@ export default function Landing() {
           </div>
           <div className="rounded-xl p-2 bg-white border border-gray-300 shadow-elevation dark:dashboard-placeholder">
             <img
-              src={placeholderImage}
+              src={theme === 'dark' ? placeholderImage : placeholderImageLight}
               alt="App preview"
               className="bg-surface rounded-lg h-64 w-full object-cover"
             />


### PR DESCRIPTION
## Summary
- show dark/light placeholders on landing page

## Testing
- `CI=true npm test --prefix frontend --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684909e3bb748321944fb1230c8e71b3