### PR TITLE
Implement clickable question titles

### DIFF
--- a/frontend/src/components/QuestionsTable.js
+++ b/frontend/src/components/QuestionsTable.js
@@ -328,8 +328,16 @@ export default function QuestionsTable({
                   </td>
 
                   {/* Title */}
-                  <td className="px-4 py-3" style={{ color: getTitleColor(q) }}>
-                    {q.title}
+                  <td className="px-4 py-3">
+                    <a
+                      href={q.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: getTitleColor(q) }}
+                      className="hover:underline"
+                    >
+                      {q.title}
+                    </a>
                   </td>
 
                   {/* Frequency */}


### PR DESCRIPTION
## Summary
- make question titles link directly to LeetCode

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684921156da88321b43cea8ea7188504