### PR TITLE
Fix sidebar default on mobile

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,7 +30,10 @@ import LeetCodeSettings  from './pages/settings/LeetCodeSettings';
 
 function AppContent() {
   // ─── Sidebar open/closed state for non-settings routes ────────────────
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Default to closed on mobile (<768px) and open otherwise
+  const [sidebarOpen, setSidebarOpen] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth >= 768 : true
+  );
   const { syncing, syncResult, user, authChecked } = useAuth();
   const showToast = syncing || syncResult != null;
 


### PR DESCRIPTION
## Summary
- keep sidebar closed by default on small screens

## Testing
- `pytest -q`
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_684935c7ad1483219edc0164021d7189