### PR TITLE
Fix sidebar closing on mobile

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -45,6 +45,9 @@ function AppContent() {
     return null;
   }
 
+  // Utility to detect mobile viewport
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+
   return (
     <div className="h-screen flex flex-col">
       {showToast && <SyncToast />}
@@ -62,6 +65,13 @@ function AppContent() {
           <SettingsSidebar sidebarOpen={sidebarOpen} />
         ) : (
           <Sidebar sidebarOpen={sidebarOpen} />
+        )}
+
+        {sidebarOpen && isMobile && (
+          <div
+            className="md:hidden fixed inset-0 top-16 bg-black/30 z-40"
+            onClick={() => setSidebarOpen(false)}
+          />
         )}
 
         {/* Main content area gets the SVG pattern and dark background */}


### PR DESCRIPTION
## Summary
- auto-detect mobile screen size in `App.js`
- add semi-transparent overlay when sidebar is open
- clicking overlay closes sidebar

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493e8f84308321af1761ecc3a03bb9