### PR TITLE
Add back navigation to Ask AI

### DIFF
--- a/frontend/src/pages/AskAIPage.jsx
+++ b/frontend/src/pages/AskAIPage.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api';
 import Loading from '../components/Loading';
 import Spinner from '../components/Spinner';
 
 export default function AskAIPage() {
   const { questionId } = useParams();
+  const navigate = useNavigate();
   const [question, setQuestion] = useState(null);
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
@@ -40,6 +41,12 @@ export default function AskAIPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <button
+        onClick={() => navigate(-1)}
+        className="text-primary hover:underline text-sm"
+      >
+        &larr; Back
+      </button>
       <h1 className="text-2xl font-bold text-primary">{question.title}</h1>
       {question.content && (
         <div className="prose dark:prose-invert border border-gray-300 dark:border-gray-700 p-4 rounded">


### PR DESCRIPTION
## Summary
- add a back button to the Ask AI conversation page

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684e36555b2c8321981ad686dbd76f01