### PR TITLE
Increase Ask AI back button size

### DIFF
--- a/frontend/src/pages/AskAIPage.jsx
+++ b/frontend/src/pages/AskAIPage.jsx
@@ -43,7 +43,7 @@ export default function AskAIPage() {
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <button
         onClick={() => navigate(-1)}
-        className="text-primary hover:underline text-sm"
+        className="text-primary hover:underline text-lg"
       >
         &larr; Back
       </button>


### PR DESCRIPTION
## Summary
- enlarge the back button on the Ask AI page for better visibility

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684e3f328a808321ae55178ef77484e1