### PR TITLE
Normalize question slugs and sync user meta

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -13,14 +13,20 @@ import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from datetime import timedelta, datetime
+
 # Adjusted import to use absolute package path
 from backend.integrity.integrity_check import verify_file_integrity
 import requests
 import re
 from dotenv import load_dotenv
 from flask import (
-    Flask, jsonify, request, abort,
-    session, send_file, send_from_directory
+    Flask,
+    jsonify,
+    request,
+    abort,
+    session,
+    send_file,
+    send_from_directory,
 )
 from bson import ObjectId
 from bson.errors import InvalidId
@@ -61,14 +67,14 @@ load_dotenv()
 if os.getenv("DISABLE_INTEGRITY_CHECK", "0").lower() not in ("1", "true"):
     if not verify_file_integrity(__file__):
         raise SystemExit("Integrity check failed")
-OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY')
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 app = Flask(
     __name__,
-    static_folder=os.path.join(BASE_DIR, 'frontend', 'build', 'static'),
-    template_folder=os.path.join(BASE_DIR, 'frontend', 'build')
+    static_folder=os.path.join(BASE_DIR, "frontend", "build", "static"),
+    template_folder=os.path.join(BASE_DIR, "frontend", "build"),
 )
 app.config.from_object(config)
 
@@ -79,24 +85,25 @@ jwt.init_app(app)
 bcrypt.init_app(app)
 mail.init_app(app)
 csrf.init_app(app)
-CORS(app, supports_credentials=True, origins=app.config['CORS_ORIGINS'].split(','))
+CORS(app, supports_credentials=True, origins=app.config["CORS_ORIGINS"].split(","))
 # ─── MongoDB collections ───────────────────────────────────────────────────
-db        = get_db()
+db = get_db()
 if os.getenv("AUTO_INDEX", "False").lower() in ("true", "1", "yes"):
     try:
         ensure_indexes(db)
     except Exception as e:
         app.logger.warning("Index setup failed: %s", e)
-QUEST     = db.questions
+QUEST = db.questions
 COMPANIES = db.companies
-CQ        = db.company_questions
+CQ = db.company_questions
 USER_META = db.user_meta
-USERS     = db.users
-FS        = gridfs.GridFS(db)
+USERS = db.users
+FS = gridfs.GridFS(db)
 
 # Cache for per-user statistics (simple in-memory)
 STATS_CACHE = {}
 STATS_TTL_SECONDS = 60
+
 
 @app.after_request
 def set_csrf_cookie(response):
@@ -110,11 +117,12 @@ def set_csrf_cookie(response):
     )
     return response
 
+
 # ─── Error Handlers ───────────────────────────────────────────────────────
 @app.errorhandler(HTTPException)
 def handle_http_exception(e):
     """Return JSON for HTTP errors."""
-    response = jsonify({'error': e.name, 'description': e.description})
+    response = jsonify({"error": e.name, "description": e.description})
     return response, e.code
 
 
@@ -122,47 +130,51 @@ def handle_http_exception(e):
 def handle_exception(e):
     """Log stack trace and return generic 500 response."""
     app.logger.exception("Unhandled exception")
-    return jsonify({'error': 'Internal Server Error'}), 500
+    return jsonify({"error": "Internal Server Error"}), 500
+
 
 # ─── Helpers ──────────────────────────────────────────────────────────────
 def generate_otp() -> str:
     return f"{random.randint(100_000, 999_999)}"
 
+
 def sanitize_text(text: str) -> str:
     """Basic HTML sanitization for user supplied strings."""
     return bleach.clean(text or "", tags=[], strip=True)
 
+
 def allowed_file(filename):
-    if '.' not in filename:
+    if "." not in filename:
         return False
-    ext = filename.rsplit('.', 1)[1].lower()
-    return ext in getattr(config, 'ALLOWED_EXTENSIONS', {'png','jpg','jpeg','gif'})
+    ext = filename.rsplit(".", 1)[1].lower()
+    return ext in getattr(config, "ALLOWED_EXTENSIONS", {"png", "jpg", "jpeg", "gif"})
+
 
 def serialize_user(user):
     """Convert a MongoDB user doc to JSON-friendly dict with photo URL."""
     if not user:
         return None
     user = dict(user)
-    user['id'] = str(user.pop('_id'))
-    photo_id = user.pop('profilePhotoId', None)
-    user['profilePhoto'] = f"/api/profile/photo/{photo_id}" if photo_id else None
+    user["id"] = str(user.pop("_id"))
+    photo_id = user.pop("profilePhotoId", None)
+    user["profilePhoto"] = f"/api/profile/photo/{photo_id}" if photo_id else None
     return user
 
 
-
 # ─── LeetCode API endpoints & fetch helpers ───────────────────────────────
-PROB_API        = "https://leetcode.com/api/problems/algorithms/"
-GRAPHQL_API     = "https://leetcode.com/graphql"
+PROB_API = "https://leetcode.com/api/problems/algorithms/"
+GRAPHQL_API = "https://leetcode.com/graphql"
 BROWSER_HEADERS = {
     "User-Agent": "Mozilla/5.0",
-    "Accept":     "application/json, text/html",
-    "Referer":    "https://leetcode.com/",
-    "Origin":     "https://leetcode.com"
+    "Accept": "application/json, text/html",
+    "Referer": "https://leetcode.com/",
+    "Origin": "https://leetcode.com",
 }
 GRAPHQL_HEADERS = {
     "User-Agent": BROWSER_HEADERS["User-Agent"],
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
 }
+
 
 def _fetch_solved_slugs_via_list(session_cookie: str) -> set[str]:
     cookies = {"LEETCODE_SESSION": session_cookie}
@@ -177,17 +189,12 @@ def _fetch_solved_slugs_via_list(session_cookie: str) -> set[str]:
     try:
         resp.raise_for_status()
     except requests.HTTPError as e:
-        app.logger.error(
-            "Problems API error %s: %s", resp.status_code, resp.text[:200]
-        )
+        app.logger.error("Problems API error %s: %s", resp.status_code, resp.text[:200])
         abort(502, description="Failed to fetch LeetCode problem list: " + str(e))
 
     data = resp.json().get("stat_status_pairs", [])
-    return {
-        p["stat"]["question__title_slug"]
-        for p in data
-        if p.get("status") == "ac"
-    }
+    return {p["stat"]["question__title_slug"] for p in data if p.get("status") == "ac"}
+
 
 def fetch_leetcode_tags(slug: str) -> list[str]:
     query = """
@@ -216,6 +223,7 @@ def fetch_leetcode_tags(slug: str) -> list[str]:
     tags = resp.json().get("data", {}).get("question", {}).get("topicTags", [])
     return [t["name"] for t in tags]
 
+
 def fetch_leetcode_content(slug: str) -> str:
     query = """
     query getQuestion($titleSlug: String!) {
@@ -240,12 +248,13 @@ def fetch_leetcode_content(slug: str) -> str:
         return ""
     return resp.json().get("data", {}).get("question", {}).get("content", "")
 
+
 def sync_leetcode(username: str, session_cookie: str, user_id: str) -> int:
     solved_slugs = _fetch_solved_slugs_via_list(session_cookie)
 
     slug_to_qid = {
         q["link"].rstrip("/").split("/")[-1]: str(q["_id"])
-        for q in QUEST.find({}, {"_id":1,"link":1})
+        for q in QUEST.find({}, {"_id": 1, "link": 1})
     }
 
     from pymongo import UpdateOne
@@ -268,95 +277,101 @@ def sync_leetcode(username: str, session_cookie: str, user_id: str) -> int:
 
     return len(ops)
 
+
 # =============================================================================
 # Authentication & User Management
 # =============================================================================
-@app.route('/auth/register', methods=['POST'])
+@app.route("/auth/register", methods=["POST"])
 def register():
     data = request.get_json() or {}
-    email             = sanitize_text((data.get('email') or '').strip().lower())
-    password          = data.get('password')
-    first_name        = sanitize_text((data.get('firstName') or '').strip())
-    last_name         = sanitize_text((data.get('lastName') or '').strip())
-    college           = sanitize_text((data.get('college') or '').strip())
-    leetcode_username = sanitize_text((data.get('leetcodeUsername') or '').strip())
+    email = sanitize_text((data.get("email") or "").strip().lower())
+    password = data.get("password")
+    first_name = sanitize_text((data.get("firstName") or "").strip())
+    last_name = sanitize_text((data.get("lastName") or "").strip())
+    college = sanitize_text((data.get("college") or "").strip())
+    leetcode_username = sanitize_text((data.get("leetcodeUsername") or "").strip())
 
     # Only firstName, email, and password are strictly required
     if not (email and password and first_name):
-        abort(400, description='First name, email, and password are required')
+        abort(400, description="First name, email, and password are required")
 
     # Basic email format validation
     import re
-    email_regex = r'^[^@\s]+@[^@\s]+\.[^@\s]+$'
-    if not re.match(email_regex, email):
-        abort(400, description='Invalid email format')
 
-    if USERS.find_one({'email': email}):
-        abort(400, description='Email already registered')
+    email_regex = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    if not re.match(email_regex, email):
+        abort(400, description="Invalid email format")
+
+    if USERS.find_one({"email": email}):
+        abort(400, description="Email already registered")
 
     otp = generate_otp()
-    session['reg_data'] = {
-        'email':             email,
-        'password':          password,
-        'firstName':         first_name,
-        'lastName':          last_name or None,
-        'college':           college or None,
-        'leetcodeUsername':  leetcode_username or None
+    session["reg_data"] = {
+        "email": email,
+        "password": password,
+        "firstName": first_name,
+        "lastName": last_name or None,
+        "college": college or None,
+        "leetcodeUsername": leetcode_username or None,
     }
-    session['otp'] = otp
+    session["otp"] = otp
 
-    msg = Message('Your Registration OTP', recipients=[email])
+    msg = Message("Your Registration OTP", recipients=[email])
     msg.body = f"Your registration OTP is {otp}"
     mail.send(msg)
-    return jsonify({'msg': 'OTP sent via email'}), 200
+    return jsonify({"msg": "OTP sent via email"}), 200
 
-@app.route('/auth/verify', methods=['POST'])
+
+@app.route("/auth/verify", methods=["POST"])
 def verify():
     data = request.get_json() or {}
-    if session.get('otp') != data.get('otp'):
-        abort(400, description='Invalid OTP')
-    reg = session.pop('reg_data', None)
-    session.pop('otp', None)
+    if session.get("otp") != data.get("otp"):
+        abort(400, description="Invalid OTP")
+    reg = session.pop("reg_data", None)
+    session.pop("otp", None)
     if not reg:
-        abort(400, description='No registration data found')
+        abort(400, description="No registration data found")
 
-    pw_hash = bcrypt.generate_password_hash(reg['password']).decode('utf-8')
-    USERS.insert_one({
-        'email':             reg['email'],
-        'password':          pw_hash,
-        'role':              'user',
-        'firstName':         reg['firstName'],
-        'lastName':         reg.get('lastName'),
-        'college':           reg.get('college'),
-        'leetcode_username': reg.get('leetcodeUsername'),
-        'leetcode_session':  None,
-        'profilePhotoId':    None,
-        'settings': {
-            'colorMode': 'leet',
-            'palette': {
-                'easy':   '#8BC34A',
-                'medium': '#FFB74D',
-                'hard':   '#E57373',
-                'solved': '#9E9E9E'
-            }
+    pw_hash = bcrypt.generate_password_hash(reg["password"]).decode("utf-8")
+    USERS.insert_one(
+        {
+            "email": reg["email"],
+            "password": pw_hash,
+            "role": "user",
+            "firstName": reg["firstName"],
+            "lastName": reg.get("lastName"),
+            "college": reg.get("college"),
+            "leetcode_username": reg.get("leetcodeUsername"),
+            "leetcode_session": None,
+            "profilePhotoId": None,
+            "settings": {
+                "colorMode": "leet",
+                "palette": {
+                    "easy": "#8BC34A",
+                    "medium": "#FFB74D",
+                    "hard": "#E57373",
+                    "solved": "#9E9E9E",
+                },
+            },
         }
-    })
-    return jsonify({'msg': 'Registration complete'}), 201
+    )
+    return jsonify({"msg": "Registration complete"}), 201
 
-@app.route('/auth/login', methods=['POST'])
+
+@app.route("/auth/login", methods=["POST"])
 def login():
     data = request.get_json() or {}
-    if not (data.get('email') and data.get('password')):
-        abort(400, description='Email and password required')
+    if not (data.get("email") and data.get("password")):
+        abort(400, description="Email and password required")
 
-    email    = (data.get('email') or '').strip().lower()
-    password = data.get('password')
-    user     = USERS.find_one({'email': email})
-    if not user or not bcrypt.check_password_hash(user['password'], password):
-        abort(401, description='Bad email or password')
+    email = (data.get("email") or "").strip().lower()
+    password = data.get("password")
+    user = USERS.find_one({"email": email})
+    if not user or not bcrypt.check_password_hash(user["password"], password):
+        abort(401, description="Bad email or password")
 
-    token = create_access_token(identity=str(user['_id']))
-    resp  = jsonify({'msg': 'Login successful'})
+    token = create_access_token(identity=str(user["_id"]))
+    resp = jsonify({"msg": "Login successful"})
     set_access_cookies(resp, token)
 
     def _bg_sync(u, s, uid):
@@ -365,100 +380,105 @@ def login():
         except Exception as e:
             app.logger.warning("Background sync failed for %s: %s", uid, e)
 
-    uname = user.get('leetcode_username')
-    sc    = user.get('leetcode_session')
+    uname = user.get("leetcode_username")
+    sc = user.get("leetcode_session")
     if uname and sc:
-        threading.Thread(target=_bg_sync, args=(uname, sc, str(user['_id'])), daemon=True).start()
+        threading.Thread(
+            target=_bg_sync, args=(uname, sc, str(user["_id"])), daemon=True
+        ).start()
 
     return resp, 200
 
-@app.route('/auth/google', methods=['POST'])
+
+@app.route("/auth/google", methods=["POST"])
 def google_login():
     """Sign up or sign in a user via a Google ID token."""
     data = request.get_json() or {}
-    id_token = data.get('idToken') or data.get('token')
+    id_token = data.get("idToken") or data.get("token")
     if not id_token:
-        abort(400, description='idToken required')
+        abort(400, description="idToken required")
 
     try:
         r = requests.get(
-            'https://oauth2.googleapis.com/tokeninfo',
-            params={'id_token': id_token},
-            timeout=5
+            "https://oauth2.googleapis.com/tokeninfo",
+            params={"id_token": id_token},
+            timeout=5,
         )
         r.raise_for_status()
     except requests.RequestException as e:
-        app.logger.error('Google token verify failed: %s', e)
-        abort(400, description='Invalid Google token')
+        app.logger.error("Google token verify failed: %s", e)
+        abort(400, description="Invalid Google token")
 
     info = r.json() or {}
-    if info.get('aud') != app.config.get('GOOGLE_CLIENT_ID'):
-        abort(400, description='Invalid Google token')
+    if info.get("aud") != app.config.get("GOOGLE_CLIENT_ID"):
+        abort(400, description="Invalid Google token")
 
-    email = info.get('email')
+    email = info.get("email")
     if not email:
-        abort(400, description='Email not available')
+        abort(400, description="Email not available")
 
-    user = USERS.find_one({'email': email})
+    user = USERS.find_one({"email": email})
     if not user:
         user_doc = {
-            'email': email,
-            'password': None,
-            'role': 'user',
-            'firstName': info.get('given_name') or '',
-            'lastName': info.get('family_name'),
-            'college': None,
-            'leetcode_username': None,
-            'leetcode_session': None,
-            'profilePhotoId': None,
-            'settings': {
-                'colorMode': 'leet',
-                'palette': {
-                    'easy': '#8BC34A',
-                    'medium': '#FFB74D',
-                    'hard': '#E57373',
-                    'solved': '#9E9E9E'
-                }
-            }
+            "email": email,
+            "password": None,
+            "role": "user",
+            "firstName": info.get("given_name") or "",
+            "lastName": info.get("family_name"),
+            "college": None,
+            "leetcode_username": None,
+            "leetcode_session": None,
+            "profilePhotoId": None,
+            "settings": {
+                "colorMode": "leet",
+                "palette": {
+                    "easy": "#8BC34A",
+                    "medium": "#FFB74D",
+                    "hard": "#E57373",
+                    "solved": "#9E9E9E",
+                },
+            },
         }
         result = USERS.insert_one(user_doc)
-        user_doc['_id'] = result.inserted_id
+        user_doc["_id"] = result.inserted_id
         user = user_doc
 
-    access = create_access_token(identity=str(user['_id']))
-    resp = jsonify({'msg': 'Login successful'})
+    access = create_access_token(identity=str(user["_id"]))
+    resp = jsonify({"msg": "Login successful"})
     set_access_cookies(resp, access)
     return resp, 200
 
-@app.route('/auth/logout', methods=['POST'])
+
+@app.route("/auth/logout", methods=["POST"])
 def logout():
-    resp = jsonify({'msg': 'Logout successful'})
+    resp = jsonify({"msg": "Logout successful"})
     unset_jwt_cookies(resp)
     session.clear()
     return resp, 200
 
-@app.route('/auth/me', methods=['GET'])
+
+@app.route("/auth/me", methods=["GET"])
 @jwt_required()
 def me():
     uid = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)}, {'password': 0})
+    user = USERS.find_one({"_id": ObjectId(uid)}, {"password": 0})
     if not user:
-        abort(404, description='User not found')
+        abort(404, description="User not found")
     return jsonify(serialize_user(user)), 200
 
-@app.route('/auth/forgot-password', methods=['POST'])
+
+@app.route("/auth/forgot-password", methods=["POST"])
 def forgot_password():
     data = request.get_json() or {}
-    user = USERS.find_one({'email': (data.get('email') or '').strip().lower()})
+    user = USERS.find_one({"email": (data.get("email") or "").strip().lower()})
     if not user:
-        abort(400, description='Email not found')
+        abort(400, description="Email not found")
 
     reset_token = create_access_token(
-        identity=str(user['_id']),
-        expires_delta=timedelta(minutes=15)
+        identity=str(user["_id"]), expires_delta=timedelta(minutes=15)
     )
 
-    msg = Message('Password Reset', recipients=[user['email']])
+    msg = Message("Password Reset", recipients=[user["email"]])
     if config.FRONTEND_URL:
         link = f"{config.FRONTEND_URL.rstrip('/')}/reset-password?token={reset_token}"
         body = (
@@ -474,101 +494,106 @@ def forgot_password():
 
     msg.body = body
     mail.send(msg)
-    return jsonify({'msg': 'Password reset email sent'}), 200
+    return jsonify({"msg": "Password reset email sent"}), 200
 
-@app.route('/auth/reset-password', methods=['POST'])
+
+@app.route("/auth/reset-password", methods=["POST"])
 def reset_password():
     data = request.get_json() or {}
     try:
-        decoded = decode_token(data.get('token'))
-        uid = decoded['sub']
+        decoded = decode_token(data.get("token"))
+        uid = decoded["sub"]
     except JWTExtendedException:
-        abort(400, description='Invalid or expired token')
+        abort(400, description="Invalid or expired token")
 
-    new_password = data.get('newPassword')
+    new_password = data.get("newPassword")
     if not new_password:
-        abort(400, description='New password is required')
+        abort(400, description="New password is required")
 
-    pw_hash = bcrypt.generate_password_hash(new_password).decode('utf-8')
-    USERS.update_one({'_id': ObjectId(uid)}, {'$set': {'password': pw_hash}})
-    return jsonify({'msg': 'Password has been reset'}), 200
+    pw_hash = bcrypt.generate_password_hash(new_password).decode("utf-8")
+    USERS.update_one({"_id": ObjectId(uid)}, {"$set": {"password": pw_hash}})
+    return jsonify({"msg": "Password has been reset"}), 200
+
 
 # =============================================================================
 # Profile: LeetCode handle + sessionCookie, sync endpoint
 # =============================================================================
-@app.route('/profile/leetcode', methods=['POST'])
+@app.route("/profile/leetcode", methods=["POST"])
 @jwt_required()
 def save_leetcode_profile():
     data = request.get_json() or {}
-    username      = (data.get('username') or '').strip()
-    sessionCookie = (data.get('sessionCookie') or '').strip()
+    username = (data.get("username") or "").strip()
+    sessionCookie = (data.get("sessionCookie") or "").strip()
     if not (username and sessionCookie):
-        abort(400, description='Both username and sessionCookie are required')
+        abort(400, description="Both username and sessionCookie are required")
 
     uid = get_jwt_identity()
     USERS.update_one(
-        {'_id': ObjectId(uid)},
-        {'$set': {
-            'leetcode_username': username,
-            'leetcode_session':  sessionCookie
-        }}
+        {"_id": ObjectId(uid)},
+        {"$set": {"leetcode_username": username, "leetcode_session": sessionCookie}},
     )
-    return jsonify({'msg': 'LeetCode profile saved'}), 200
+    return jsonify({"msg": "LeetCode profile saved"}), 200
 
-@app.route('/profile/leetcode/sync', methods=['POST'])
+
+@app.route("/profile/leetcode/sync", methods=["POST"])
 @jwt_required()
 def manual_leetcode_sync():
-    uid  = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)})
-    if not user or not user.get('leetcode_username') or not user.get('leetcode_session'):
-        abort(400, description='Username & sessionCookie must be set first')
+    uid = get_jwt_identity()
+    user = USERS.find_one({"_id": ObjectId(uid)})
+    if (
+        not user
+        or not user.get("leetcode_username")
+        or not user.get("leetcode_session")
+    ):
+        abort(400, description="Username & sessionCookie must be set first")
 
     synced = sync_leetcode(
-        user['leetcode_username'],
-        user['leetcode_session'],
-        str(uid)
+        user["leetcode_username"], user["leetcode_session"], str(uid)
     )
 
-    return jsonify({'synced': synced}), 200
+    return jsonify({"synced": synced}), 200
+
 
 # ─── Update per‐user color settings ────────────────────────────────────────
-@app.route('/profile/settings', methods=['PATCH'])
+@app.route("/profile/settings", methods=["PATCH"])
 @jwt_required()
 def update_profile_settings():
     data = request.get_json() or {}
-    allowed = {'easy', 'medium', 'hard', 'solved'}
+    allowed = {"easy", "medium", "hard", "solved"}
     update = {}
 
-    if 'colorMode' in data and data['colorMode'] in ['leet', 'user']:
-        update['settings.colorMode'] = data['colorMode']
+    if "colorMode" in data and data["colorMode"] in ["leet", "user"]:
+        update["settings.colorMode"] = data["colorMode"]
 
-    if 'palette' in data and isinstance(data['palette'], dict):
+    if "palette" in data and isinstance(data["palette"], dict):
         for k in allowed:
-            if k in data['palette']:
-                update[f'settings.palette.{k}'] = data['palette'][k]
+            if k in data["palette"]:
+                update[f"settings.palette.{k}"] = data["palette"][k]
 
     if not update:
         abort(400, description="No valid settings to update")
 
     uid = get_jwt_identity()
-    USERS.update_one({'_id': ObjectId(uid)}, {'$set': update})
-    result = USERS.find_one({'_id': ObjectId(uid)}, {'settings': 1, '_id': 0})
-    return jsonify(result.get('settings', {})), 200
+    USERS.update_one({"_id": ObjectId(uid)}, {"$set": update})
+    result = USERS.find_one({"_id": ObjectId(uid)}, {"settings": 1, "_id": 0})
+    return jsonify(result.get("settings", {})), 200
+
 
 # =============================================================================
 # NEW: Account Settings & Profile Photo Endpoints
 # =============================================================================
-@app.route('/profile/account', methods=['GET'])
+@app.route("/profile/account", methods=["GET"])
 @jwt_required()
 def get_account_profile():
     """Fetch the current user's account details (excluding password)."""
     uid = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)}, {'password': 0})
+    user = USERS.find_one({"_id": ObjectId(uid)}, {"password": 0})
     if not user:
-        abort(404, description='User not found')
+        abort(404, description="User not found")
     return jsonify(serialize_user(user)), 200
 
-@app.route('/profile/account', methods=['PATCH'])
+
+@app.route("/profile/account", methods=["PATCH"])
 @jwt_required()
 def update_account_profile():
     """
@@ -580,133 +605,140 @@ def update_account_profile():
     update = {}
 
     # Validate and set firstName
-    if 'firstName' in data:
-        new_first = sanitize_text((data.get('firstName') or '').strip())
+    if "firstName" in data:
+        new_first = sanitize_text((data.get("firstName") or "").strip())
         if not new_first:
-            abort(400, description='First name cannot be empty')
-        update['firstName'] = new_first
+            abort(400, description="First name cannot be empty")
+        update["firstName"] = new_first
 
     # lastName (optional)
-    if 'lastName' in data:
-       update['lastName'] = sanitize_text((data.get('lastName') or '').strip()) or None
+    if "lastName" in data:
+        update["lastName"] = sanitize_text((data.get("lastName") or "").strip()) or None
 
     # college (optional)
-    if 'college' in data:
-        update['college'] = sanitize_text((data.get('college') or '').strip()) or None
-       
+    if "college" in data:
+        update["college"] = sanitize_text((data.get("college") or "").strip()) or None
+
     # email (required & unique if changed)
-    if 'email' in data:
-        new_email = sanitize_text((data.get('email') or '').strip().lower())
+    if "email" in data:
+        new_email = sanitize_text((data.get("email") or "").strip().lower())
         if not new_email:
-            abort(400, description='Email cannot be empty')
+            abort(400, description="Email cannot be empty")
         # Basic email format validation
         import re
-        email_regex = r'^[^@\s]+@[^@\s]+\.[^@\s]+$'
+
+        email_regex = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
         if not re.match(email_regex, new_email):
-            abort(400, description='Invalid email format')
+            abort(400, description="Invalid email format")
         # Check if email already exists on a different user
-        existing = USERS.find_one({'email': new_email})
-        if existing and str(existing['_id']) != uid:
-            abort(400, description='Email is already in use')
-        update['email'] = new_email
+        existing = USERS.find_one({"email": new_email})
+        if existing and str(existing["_id"]) != uid:
+            abort(400, description="Email is already in use")
+        update["email"] = new_email
 
     # newPassword (optional)
-    if 'newPassword' in data:
-        new_pw = data.get('newPassword')
+    if "newPassword" in data:
+        new_pw = data.get("newPassword")
         if not new_pw or len(new_pw) < 8:
-            abort(400, description='New password must be at least 8 characters')
-        pw_hash = bcrypt.generate_password_hash(new_pw).decode('utf-8')
-        update['password'] = pw_hash
+            abort(400, description="New password must be at least 8 characters")
+        pw_hash = bcrypt.generate_password_hash(new_pw).decode("utf-8")
+        update["password"] = pw_hash
 
     if not update:
-        abort(400, description='No valid fields to update')
+        abort(400, description="No valid fields to update")
 
-    USERS.update_one({'_id': ObjectId(uid)}, {'$set': update})
+    USERS.update_one({"_id": ObjectId(uid)}, {"$set": update})
     # Return updated user (excluding password)
-    updated_user = USERS.find_one({'_id': ObjectId(uid)}, {'password': 0})
+    updated_user = USERS.find_one({"_id": ObjectId(uid)}, {"password": 0})
     return jsonify(serialize_user(updated_user)), 200
 
-@app.route('/profile/account/photo', methods=['POST'])
+
+@app.route("/profile/account/photo", methods=["POST"])
 @jwt_required()
 def upload_profile_photo():
     """Upload (or replace) a profile photo to GridFS."""
     uid = get_jwt_identity()
-    if 'photo' not in request.files:
-        abort(400, description='No file part in the request')
+    if "photo" not in request.files:
+        abort(400, description="No file part in the request")
 
-    file = request.files['photo']
-    if file.filename == '':
-        abort(400, description='No selected file')
+    file = request.files["photo"]
+    if file.filename == "":
+        abort(400, description="No selected file")
     if not allowed_file(file.filename):
-        abort(400, description='File type not allowed')
+        abort(400, description="File type not allowed")
 
-    ext = file.filename.rsplit('.', 1)[1].lower()
+    ext = file.filename.rsplit(".", 1)[1].lower()
     filename = f"{uid}.{ext}"
 
     try:
         # remove old photo if exists
-        old = USERS.find_one({'_id': ObjectId(uid)}, {'profilePhotoId': 1})
-        if old and old.get('profilePhotoId'):
+        old = USERS.find_one({"_id": ObjectId(uid)}, {"profilePhotoId": 1})
+        if old and old.get("profilePhotoId"):
             try:
-                FS.delete(old['profilePhotoId'])
+                FS.delete(old["profilePhotoId"])
             except Exception as e:
-                app.logger.warning("Could not delete old photo %s: %s", old['profilePhotoId'], e)
+                app.logger.warning(
+                    "Could not delete old photo %s: %s", old["profilePhotoId"], e
+                )
 
         file_id = FS.put(file.stream, filename=filename, content_type=file.content_type)
     except Exception as e:
         app.logger.error("Failed to save profile photo: %s", e)
-        abort(500, description='Failed to save photo')
+        abort(500, description="Failed to save photo")
 
-    USERS.update_one({'_id': ObjectId(uid)}, {'$set': {'profilePhotoId': file_id}})
+    USERS.update_one({"_id": ObjectId(uid)}, {"$set": {"profilePhotoId": file_id}})
     photo_url = f"/api/profile/photo/{file_id}"
-    return jsonify({'profilePhotoUrl': photo_url}), 200
+    return jsonify({"profilePhotoUrl": photo_url}), 200
 
-@app.route('/profile/account/photo', methods=['DELETE'])
+
+@app.route("/profile/account/photo", methods=["DELETE"])
 @jwt_required()
 def delete_profile_photo():
     """Remove the existing profile photo from GridFS and unset the field."""
     uid = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)}, {'profilePhotoId': 1})
+    user = USERS.find_one({"_id": ObjectId(uid)}, {"profilePhotoId": 1})
     if not user:
-        abort(404, description='User not found')
+        abort(404, description="User not found")
 
-    photo_id = user.get('profilePhotoId')
+    photo_id = user.get("profilePhotoId")
     if photo_id:
         try:
             FS.delete(photo_id)
         except Exception as e:
             app.logger.warning("Could not delete photo file %s: %s", photo_id, e)
 
-    USERS.update_one({'_id': ObjectId(uid)}, {'$unset': {'profilePhotoId': ""}})
-    return jsonify({'msg': 'Profile photo removed'}), 200
+    USERS.update_one({"_id": ObjectId(uid)}, {"$unset": {"profilePhotoId": ""}})
+    return jsonify({"msg": "Profile photo removed"}), 200
 
 
-@app.route('/api/profile/photo/<file_id>', methods=['GET'])
+@app.route("/api/profile/photo/<file_id>", methods=["GET"])
 @jwt_required()
 def get_profile_photo(file_id):
     """Stream a profile photo stored in GridFS."""
     try:
         oid = ObjectId(file_id)
     except (InvalidId, TypeError):
-        abort(400, description='Invalid file id')
+        abort(400, description="Invalid file id")
     try:
         grid_out = FS.get(oid)
     except gridfs.NoFile:
-        abort(404, description='File not found')
+        abort(404, description="File not found")
     return send_file(BytesIO(grid_out.read()), mimetype=grid_out.content_type)
+
 
 # =============================================================================
 # Health-check
 # =============================================================================
-@app.route('/api/ping', methods=['GET'])
+@app.route("/api/ping", methods=["GET"])
 @jwt_required()
 def ping():
-    return jsonify({'msg': 'pong'}), 200
+    return jsonify({"msg": "pong"}), 200
+
 
 # =============================================================================
 # Admin CSV / Excel import
 # =============================================================================
-@app.route('/api/import', methods=['POST'])
+@app.route("/api/import", methods=["POST"])
 @jwt_required()
 def import_questions():
     """
@@ -719,338 +751,348 @@ def import_questions():
         otherwise we create the company on the fly.
     """
     # 1) Authorize ─────────────────────────────────────────────────────────
-    uid  = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)})
-    if user.get('role') != 'admin':
-        abort(403, description='Only admin can import questions')
+    uid = get_jwt_identity()
+    user = USERS.find_one({"_id": ObjectId(uid)})
+    if user.get("role") != "admin":
+        abort(403, description="Only admin can import questions")
 
-    if 'file' not in request.files:
-        abort(400, description='File field is required')
+    if "file" not in request.files:
+        abort(400, description="File field is required")
 
-    up_file = request.files['file']
-    if up_file.filename == '':
-        abort(400, description='No file selected')
+    up_file = request.files["file"]
+    if up_file.filename == "":
+        abort(400, description="No file selected")
 
-    ext = up_file.filename.rsplit('.', 1)[-1].lower()
+    ext = up_file.filename.rsplit(".", 1)[-1].lower()
     try:
-        if ext == 'csv':
+        if ext == "csv":
             df = pd.read_csv(up_file.stream)
-        elif ext in ('xlsx', 'xls'):
+        elif ext in ("xlsx", "xls"):
             # Must read the raw bytes first; BytesIO lets pandas parse it
-            df = pd.read_excel(BytesIO(up_file.read()), engine='openpyxl')
+            df = pd.read_excel(BytesIO(up_file.read()), engine="openpyxl")
         else:
-            abort(400, description='Unsupported file type; only CSV/Excel')
+            abort(400, description="Unsupported file type; only CSV/Excel")
     except (EmptyDataError, pd.errors.ParserError) as e:
-        abort(400, description=f'Could not parse file: {e}')
+        abort(400, description=f"Could not parse file: {e}")
 
     if df.empty:
-        abort(400, description='Uploaded file contained no rows')
+        abort(400, description="Uploaded file contained no rows")
 
     # ── Normalize column names: strip & lower for lookup convenience ──────
     df.columns = [c.strip().lower() for c in df.columns]
 
-    required_cols = {'title', 'link', 'company', 'bucket'}
+    required_cols = {"title", "link", "company", "bucket"}
     if not required_cols.issubset(set(df.columns)):
         missing = required_cols - set(df.columns)
-        abort(400, description=f'Missing required columns: {missing}')
+        abort(400, description=f"Missing required columns: {missing}")
 
     imported, skipped = 0, 0
 
     for _, row in df.iterrows():
-        title   = str(row.get('title') or '').strip()
-        link    = str(row.get('link') or row.get('url') or '').strip()
-        company = str(row.get('company') or '').strip()
-        bucket  = str(row.get('bucket') or '').strip()           # e.g. “30Days”, “3Months”, etc.
+        title = str(row.get("title") or "").strip()
+        link = str(row.get("link") or row.get("url") or "").strip()
+        company = str(row.get("company") or "").strip()
+        bucket = str(row.get("bucket") or "").strip()  # e.g. “30Days”, “3Months”, etc.
 
         if not (title and link and company and bucket):
             skipped += 1
             continue  # malformed row
 
         try:
-            freq = float(row.get('frequency') or 0)
+            freq = float(row.get("frequency") or 0)
         except (ValueError, TypeError):
             freq = 0.0
 
         try:
-            acc = float(row.get('acceptancerate') or 0)
+            acc = float(row.get("acceptancerate") or 0)
         except (ValueError, TypeError):
             acc = 0.0
 
-        ldiff = str(row.get('difficulty') or '').capitalize().strip()
+        ldiff = str(row.get("difficulty") or "").capitalize().strip()
 
         # 2) Upsert canonical question ───────────────────────────────────
         q_doc = QUEST.find_one_and_update(
-            {'link': link},
-            {'$setOnInsert': {
-                'link': link,
-                'title': title,
-                'leetDifficulty': ldiff or None
-            }},
+            {"link": link},
+            {
+                "$setOnInsert": {
+                    "link": link,
+                    "title": title,
+                    "leetDifficulty": ldiff or None,
+                }
+            },
             upsert=True,
-            return_document=True
+            return_document=True,
         )
-        qid = q_doc['_id']
+        qid = q_doc["_id"]
 
         # 3) Fetch (or insert) company ────────────────────────────────────
         c_doc = COMPANIES.find_one_and_update(
-            {'name': company},
-            {'$setOnInsert': {'name': company}},
+            {"name": company},
+            {"$setOnInsert": {"name": company}},
             upsert=True,
-            return_document=True
+            return_document=True,
         )
-        cid = c_doc['_id']
+        cid = c_doc["_id"]
 
         # 4) Upsert join row (company × bucket × question) ───────────────
         CQ.replace_one(
-            {'company_id': cid, 'question_id': qid, 'bucket': bucket},
+            {"company_id": cid, "question_id": qid, "bucket": bucket},
             {
-                'company_id':    cid,
-                'question_id':   qid,
-                'bucket':        bucket,
-                'frequency':     freq,
-                'acceptanceRate': acc
+                "company_id": cid,
+                "question_id": qid,
+                "bucket": bucket,
+                "frequency": freq,
+                "acceptanceRate": acc,
             },
-            upsert=True
+            upsert=True,
         )
         imported += 1
 
-    return jsonify({
-        'imported': imported,
-        'skipped':  skipped
-    }), 201
+    return jsonify({"imported": imported, "skipped": skipped}), 201
+
 
 # ─── Admin-only: backfill tags for existing questions ─────────────────────
-@app.route('/api/admin/backfill-tags', methods=['POST'])
+@app.route("/api/admin/backfill-tags", methods=["POST"])
 @jwt_required()
 def backfill_tags():
     uid = get_jwt_identity()
-    user = USERS.find_one({'_id': ObjectId(uid)})
-    if user.get('role') != 'admin':
-        abort(403, description='Only admin can run backfill')
+    user = USERS.find_one({"_id": ObjectId(uid)})
+    if user.get("role") != "admin":
+        abort(403, description="Only admin can run backfill")
 
-    cursor = QUEST.find({}, {'link': 1})
-    slugs = [
-        (q['_id'], q['link'].rstrip('/').split('/')[-1])
-        for q in cursor
-    ]
+    cursor = QUEST.find({}, {"link": 1})
+    slugs = [(q["_id"], q["link"].rstrip("/").split("/")[-1]) for q in cursor]
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         future_to_id = {
-            pool.submit(fetch_leetcode_tags, slug): qid
-            for qid, slug in slugs
+            pool.submit(fetch_leetcode_tags, slug): qid for qid, slug in slugs
         }
         for fut in concurrent.futures.as_completed(future_to_id):
             qid = future_to_id[fut]
             try:
                 tags = fut.result()
             except Exception as e:
-                app.logger.warning('Failed to backfill tags for %s: %s', qid, e)
+                app.logger.warning("Failed to backfill tags for %s: %s", qid, e)
                 tags = []
-            QUEST.update_one({'_id': qid}, {'$set': {'tags': tags}})
+            QUEST.update_one({"_id": qid}, {"$set": {"tags": tags}})
 
-    return jsonify({'msg': 'Backfill complete'}), 200
+    return jsonify({"msg": "Backfill complete"}), 200
+
 
 # =============================================================================
 # Public listings & per-user metadata
 # =============================================================================
-@app.route('/api/companies', methods=['GET'])
+@app.route("/api/companies", methods=["GET"])
 @jwt_required()
 def list_companies():
-    return jsonify(COMPANIES.distinct('name')), 200
+    return jsonify(COMPANIES.distinct("name")), 200
 
-@app.route('/api/companies/<company>/buckets', methods=['GET'])
+
+@app.route("/api/companies/<company>/buckets", methods=["GET"])
 @jwt_required()
 def list_buckets(company):
-    co = COMPANIES.find_one({'name': company})
+    co = COMPANIES.find_one({"name": company})
     if not co:
         abort(404, description=f"No company '{company}'")
-    return jsonify(CQ.distinct('bucket', {'company_id': co['_id']})), 200
+    return jsonify(CQ.distinct("bucket", {"company_id": co["_id"]})), 200
 
-@app.route('/api/companies/<company>/topics', methods=['GET'])
+
+@app.route("/api/companies/<company>/topics", methods=["GET"])
 @jwt_required()
 def get_company_topics(company):
-    co = COMPANIES.find_one({'name': company})
+    co = COMPANIES.find_one({"name": company})
     if not co:
         abort(404, description=f"No company '{company}'")
 
-    bucket   = request.args.get('bucket', 'All')
-    unsolved = request.args.get('unsolved', 'false').lower() == 'true'
-    uid      = get_jwt_identity()
+    bucket = request.args.get("bucket", "All")
+    unsolved = request.args.get("unsolved", "false").lower() == "true"
+    uid = get_jwt_identity()
 
-    match = {'company_id': co['_id']}
+    match = {"company_id": co["_id"]}
     # When "All" bucket is requested, restrict to the actual "All" bucket
     # document instead of every bucket to avoid duplicates.
     # The CSV/Excel dataset already contains a pre-made "All" bucket with
     # unique questions, so querying all buckets would return duplicates.
-    if bucket != 'All':
-        match['bucket'] = bucket
+    if bucket != "All":
+        match["bucket"] = bucket
     else:
-        match['bucket'] = 'All'
+        match["bucket"] = "All"
 
     pipeline = [
-        {'$match': match},
+        {"$match": match},
         # Deduplicate questions in case multiple company_question documents
         # exist for the same question ID and bucket.
-        {'$group': {'_id': '$question_id'}},
-        {'$set': {'question_id': '$_id'}},
-        {'$lookup': {
-            'from': 'questions',
-            'localField': 'question_id',
-            'foreignField': '_id',
-            'as': 'q'
-        }},
-        {'$unwind': '$q'}
+        {"$group": {"_id": "$question_id"}},
+        {"$set": {"question_id": "$_id"}},
+        {
+            "$lookup": {
+                "from": "questions",
+                "localField": "question_id",
+                "foreignField": "_id",
+                "as": "q",
+            }
+        },
+        {"$unwind": "$q"},
     ]
 
     if unsolved:
         pipeline += [
-            {'$lookup': {
-                'from': 'user_meta',
-                'let': {'qid': '$question_id'},
-                'pipeline': [
-                    {'$match': {
-                        '$expr': {
-                            '$and': [
-                                {'$eq': ['$question_id', {'$toString': '$$qid'}]},
-                                {'$eq': ['$user_id', uid]}
-                            ]
-                        }
-                    }},
-                    {'$project': {'solved': 1}}
-                ],
-                'as': 'meta'
-            }},
-            {'$match': {
-                '$or': [
-                    {'meta': {'$eq': []}},
-                    {'meta.0.solved': False}
-                ]
-            }}
+            {
+                "$lookup": {
+                    "from": "user_meta",
+                    "let": {"qid": "$question_id"},
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "$expr": {
+                                    "$and": [
+                                        {
+                                            "$eq": [
+                                                "$question_id",
+                                                {"$toString": "$$qid"},
+                                            ]
+                                        },
+                                        {"$eq": ["$user_id", uid]},
+                                    ]
+                                }
+                            }
+                        },
+                        {"$project": {"solved": 1}},
+                    ],
+                    "as": "meta",
+                }
+            },
+            {"$match": {"$or": [{"meta": {"$eq": []}}, {"meta.0.solved": False}]}},
         ]
 
     pipeline += [
-        {'$unwind': '$q.tags'},
-        {'$group':   {'_id': '$q.tags', 'count': {'$sum': 1}}},
-        {'$sort':    {'count': -1}}
+        {"$unwind": "$q.tags"},
+        {"$group": {"_id": "$q.tags", "count": {"$sum": 1}}},
+        {"$sort": {"count": -1}},
     ]
 
     results = list(CQ.aggregate(pipeline))
-    topics  = [{'tag': r['_id'], 'count': r['count']} for r in results]
-    return jsonify({'data': topics}), 200
+    topics = [{"tag": r["_id"], "count": r["count"]} for r in results]
+    return jsonify({"data": topics}), 200
 
-@app.route('/api/companies/<company>/buckets/<bucket>/questions', methods=['GET'])
+
+@app.route("/api/companies/<company>/buckets/<bucket>/questions", methods=["GET"])
 @jwt_required()
 def list_questions(company, bucket):
-    co = COMPANIES.find_one({'name': company})
+    co = COMPANIES.find_one({"name": company})
     if not co:
         abort(404, description=f"No company '{company}'")
 
-    page         = int(request.args.get('page', 1))
-    limit        = int(request.args.get('limit', 50))
-    skip         = (page - 1) * limit
-    search       = request.args.get('search')
+    page = int(request.args.get("page", 1))
+    limit = int(request.args.get("limit", 50))
+    skip = (page - 1) * limit
+    search = request.args.get("search")
     if search:
         if len(search) > 100:
-            abort(400, description='Search query too long')
+            abort(400, description="Search query too long")
         search = re.escape(search)
-    sortField    = request.args.get('sortField')
-    sortOrder    = request.args.get('sortOrder', 'asc')
-    tag_filter   = request.args.get('tag')
-    showUnsolved = request.args.get('showUnsolved', 'false').lower() == 'true'
+    sortField = request.args.get("sortField")
+    sortOrder = request.args.get("sortOrder", "asc")
+    tag_filter = request.args.get("tag")
+    showUnsolved = request.args.get("showUnsolved", "false").lower() == "true"
 
-    match = {'company_id': co['_id']}
+    match = {"company_id": co["_id"]}
     # Show the dedicated "All" bucket instead of combining all buckets to
     # avoid duplicates when viewing "All" questions for a company.
-    if bucket != 'All':
-        match['bucket'] = bucket
+    if bucket != "All":
+        match["bucket"] = bucket
     else:
-        match['bucket'] = 'All'
+        match["bucket"] = "All"
 
     pipeline = [
-        {'$match': match},
+        {"$match": match},
         # Group by question to avoid duplicates if multiple rows exist
-        {'$group': {
-            '_id': '$question_id',
-            'frequency': {'$max': '$frequency'},
-            'acceptanceRate': {'$max': '$acceptanceRate'}
-        }},
-        {'$set': {'question_id': '$_id'}},
-        {'$lookup': {
-            'from': 'questions',
-            'localField': 'question_id',
-            'foreignField': '_id',
-            'as': 'q'
-        }},
-        {'$unwind': '$q'}
+        {
+            "$group": {
+                "_id": "$question_id",
+                "frequency": {"$max": "$frequency"},
+                "acceptanceRate": {"$max": "$acceptanceRate"},
+            }
+        },
+        {"$set": {"question_id": "$_id"}},
+        {
+            "$lookup": {
+                "from": "questions",
+                "localField": "question_id",
+                "foreignField": "_id",
+                "as": "q",
+            }
+        },
+        {"$unwind": "$q"},
     ]
 
     if tag_filter:
-        pipeline.append({'$match': {'q.tags': tag_filter}})
+        pipeline.append({"$match": {"q.tags": tag_filter}})
 
     if search:
-        pipeline.append({
-            '$match': {
-                'q.title': {'$regex': search, '$options': 'i'}
-            }
-        })
+        pipeline.append({"$match": {"q.title": {"$regex": search, "$options": "i"}}})
 
     fmap = {
-        'title':          'q.title',
-        'frequency':      'frequency',
-        'acceptanceRate': 'acceptanceRate',
-        'leetDifficulty': 'q.leetDifficulty'
+        "title": "q.title",
+        "frequency": "frequency",
+        "acceptanceRate": "acceptanceRate",
+        "leetDifficulty": "q.leetDifficulty",
     }
     if sortField in fmap:
-        pipeline.append({
-            '$sort': {fmap[sortField]: 1 if sortOrder == 'asc' else -1}
-        })
+        pipeline.append({"$sort": {fmap[sortField]: 1 if sortOrder == "asc" else -1}})
+    else:
+        pipeline.append({"$sort": {"q.title": 1}})
 
-    total_count = list(CQ.aggregate(pipeline + [{'$count': 'c'}]))
-    total = total_count[0]['c'] if total_count else 0
+    total_count = list(CQ.aggregate(pipeline + [{"$count": "c"}]))
+    total = total_count[0]["c"] if total_count else 0
 
-    pipeline += [
-        {'$skip': skip},
-        {'$limit': limit}
-    ]
+    pipeline += [{"$skip": skip}, {"$limit": limit}]
 
     results = list(CQ.aggregate(pipeline))
 
     uid = get_jwt_identity()
-    qids = [str(r['q']['_id']) for r in results]
+    qids = [str(r["q"]["_id"]) for r in results]
 
     meta_generic = {
-        m['question_id']: m
-        for m in USER_META.find({'user_id': uid, 'question_id': {'$in': qids}})
+        m["question_id"]: m
+        for m in USER_META.find({"user_id": uid, "question_id": {"$in": qids}})
     }
 
-    meta_filter = {'user_id': uid, 'company_id': co['_id'], 'question_id': {'$in': qids}}
-    if bucket != 'All':
-        meta_filter['bucket'] = bucket
-    meta_specific = {m['question_id']: m for m in USER_META.find(meta_filter)}
+    meta_filter = {
+        "user_id": uid,
+        "company_id": co["_id"],
+        "question_id": {"$in": qids},
+    }
+    if bucket != "All":
+        meta_filter["bucket"] = bucket
+    meta_specific = {m["question_id"]: m for m in USER_META.find(meta_filter)}
 
     out = []
     for doc in results:
-        q = doc['q']
-        qid_str = str(q['_id'])
+        q = doc["q"]
+        qid_str = str(q["_id"])
         meta = meta_specific.get(qid_str) or meta_generic.get(qid_str)
-        solved = meta.get('solved', False) if meta else False
+        solved = meta.get("solved", False) if meta else False
         if showUnsolved and solved:
             continue
 
-        out.append({
-            'id':             qid_str,
-            'title':          q['title'],
-            'link':           q['link'],
-            'frequency':      doc.get('frequency'),
-            'acceptanceRate': doc.get('acceptanceRate'),
-            'leetDifficulty': q.get('leetDifficulty'),
-            'solved':         solved,
-            'userDifficulty': meta.get('userDifficulty') if meta else None
-        })
+        out.append(
+            {
+                "id": qid_str,
+                "title": q["title"],
+                "link": q["link"],
+                "frequency": doc.get("frequency"),
+                "acceptanceRate": doc.get("acceptanceRate"),
+                "leetDifficulty": q.get("leetDifficulty"),
+                "solved": solved,
+                "userDifficulty": meta.get("userDifficulty") if meta else None,
+            }
+        )
 
-    return jsonify({'data': out, 'total': total}), 200
+    return jsonify({"data": out, "total": total}), 200
 
-@app.route('/api/questions/<question_id>', methods=['GET'])
+
+@app.route("/api/questions/<question_id>", methods=["GET"])
 @jwt_required()
 def get_question(question_id):
     try:
@@ -1058,23 +1100,24 @@ def get_question(question_id):
     except InvalidId:
         abort(400, description=f"Invalid question ID '{question_id}'")
 
-    q = QUEST.find_one({'_id': q_oid})
+    q = QUEST.find_one({"_id": q_oid})
     if not q:
         abort(404, description=f"Question '{question_id}' not found")
 
-    slug = q['link'].rstrip('/').split('/')[-1]
+    slug = q["link"].rstrip("/").split("/")[-1]
     content = fetch_leetcode_content(slug)
     resp = {
-        'id': str(q['_id']),
-        'title': q.get('title'),
-        'link': q.get('link'),
-        'leetDifficulty': q.get('leetDifficulty'),
-        'tags': q.get('tags', []),
-        'content': content
+        "id": str(q["_id"]),
+        "title": q.get("title"),
+        "link": q.get("link"),
+        "leetDifficulty": q.get("leetDifficulty"),
+        "tags": q.get("tags", []),
+        "content": content,
     }
     return jsonify(resp), 200
 
-@app.route('/api/questions/<question_id>', methods=['PATCH'])
+
+@app.route("/api/questions/<question_id>", methods=["PATCH"])
 @jwt_required()
 def update_question_meta(question_id):
     uid = get_jwt_identity()
@@ -1084,137 +1127,200 @@ def update_question_meta(question_id):
     except InvalidId:
         abort(400, description=f"Invalid question ID '{question_id}'")
 
-    if not QUEST.find_one({'_id': q_oid}):
+    if not QUEST.find_one({"_id": q_oid}):
         abort(404, description=f"Question '{question_id}' not found")
 
     data = request.get_json() or {}
     update_fields = {}
 
-    company_name = data.get('company')
-    bucket       = data.get('bucket')
-    company_id   = None
+    company_name = data.get("company")
+    bucket = data.get("bucket")
+    company_id = None
     if company_name and bucket:
-        co = COMPANIES.find_one({'name': company_name})
+        co = COMPANIES.find_one({"name": company_name})
         if not co:
             abort(404, description=f"No company '{company_name}'")
-        company_id = co['_id']
+        company_id = co["_id"]
 
-    if 'solved' in data:
-        update_fields['solved'] = bool(data['solved'])
-    if 'userDifficulty' in data:
-        update_fields['userDifficulty'] = data.get('userDifficulty') or None
+    if "solved" in data:
+        update_fields["solved"] = bool(data["solved"])
+    if "userDifficulty" in data:
+        update_fields["userDifficulty"] = data.get("userDifficulty") or None
 
     if not update_fields:
         abort(400, description="No valid fields to update (solved, userDifficulty)")
 
-    update_fields['updatedAt'] = datetime.utcnow()
+    update_fields["updatedAt"] = datetime.utcnow()
 
-
-    query = {'user_id': uid, 'question_id': question_id}
+    query = {"user_id": uid, "question_id": question_id}
     if company_id:
-        query.update({'company_id': company_id, 'bucket': bucket})
+        query_specific = query | {"company_id": company_id, "bucket": bucket}
+    else:
+        query_specific = query
 
     meta = USER_META.find_one_and_update(
-        query,
-        {'$set': update_fields | ({'company_id': company_id, 'bucket': bucket} if company_id else {})},
+        query_specific,
+        {
+            "$set": update_fields
+            | ({"company_id": company_id, "bucket": bucket} if company_id else {})
+        },
         upsert=True,
         return_document=True,
     )
+
+    # Ensure a generic record exists and update all other bucket records
+    generic_update = {
+        "$set": {
+            k: update_fields[k]
+            for k in ["solved", "userDifficulty"]
+            if k in update_fields
+        }
+    }
+    USER_META.update_one(query, generic_update, upsert=True)
+
+    USER_META.update_many(
+        (
+            {
+                **query,
+                "$or": [
+                    {"company_id": {"$ne": company_id}},
+                    {"bucket": {"$ne": bucket}},
+                ],
+            }
+            if company_id
+            else {**query, "company_id": {"$exists": True}}
+        ),
+        generic_update,
+    )
+
     resp = {
-        'question_id':    question_id,
-        'solved':         meta.get('solved', False),
-        'userDifficulty': meta.get('userDifficulty')
+        "question_id": question_id,
+        "solved": meta.get("solved", False),
+        "userDifficulty": meta.get("userDifficulty"),
     }
     return jsonify(resp), 200
 
-@app.route('/api/questions/batch-meta', methods=['PATCH'])
+
+@app.route("/api/questions/batch-meta", methods=["PATCH"])
 @jwt_required()
 def batch_update_questions_meta():
-    uid   = get_jwt_identity()
-    data  = request.get_json() or {}
-    ids   = data.get('ids')
+    uid = get_jwt_identity()
+    data = request.get_json() or {}
+    ids = data.get("ids")
     if not isinstance(ids, list) or not ids:
         abort(400, description="Field 'ids' must be a non-empty list")
 
     update_fields = {}
-    if 'solved' in data:
-        update_fields['solved'] = bool(data['solved'])
-    if 'userDifficulty' in data:
-        update_fields['userDifficulty'] = data.get('userDifficulty') or None
+    if "solved" in data:
+        update_fields["solved"] = bool(data["solved"])
+    if "userDifficulty" in data:
+        update_fields["userDifficulty"] = data.get("userDifficulty") or None
     if not update_fields:
         abort(400, description="No valid fields to update (solved, userDifficulty)")
 
-    update_fields['updatedAt'] = datetime.utcnow()
+    update_fields["updatedAt"] = datetime.utcnow()
 
-    company_name = data.get('company')
-    bucket       = data.get('bucket')
-    company_id   = None
+    company_name = data.get("company")
+    bucket = data.get("bucket")
+    company_id = None
     if company_name and bucket:
-        co = COMPANIES.find_one({'name': company_name})
+        co = COMPANIES.find_one({"name": company_name})
         if not co:
             abort(404, description=f"No company '{company_name}'")
-        company_id = co['_id']
-
+        company_id = co["_id"]
 
     from pymongo import UpdateOne
 
     ops = []
     for qid in ids:
-        query = {'user_id': uid, 'question_id': qid}
+        query_base = {"user_id": uid, "question_id": qid}
         if company_id:
-            query.update({'company_id': company_id, 'bucket': bucket})
+            query_specific = query_base | {"company_id": company_id, "bucket": bucket}
+        else:
+            query_specific = query_base
+
         ops.append(
             UpdateOne(
-                query,
-                {'$set': update_fields | ({'company_id': company_id, 'bucket': bucket} if company_id else {})},
+                query_specific,
+                {
+                    "$set": update_fields
+                    | (
+                        {"company_id": company_id, "bucket": bucket}
+                        if company_id
+                        else {}
+                    )
+                },
                 upsert=True,
             )
         )
 
+        generic_update = {
+            "$set": {
+                k: update_fields[k]
+                for k in ["solved", "userDifficulty"]
+                if k in update_fields
+            }
+        }
+        ops.append(UpdateOne(query_base, generic_update, upsert=True))
+        if company_id:
+            ops.append(
+                UpdateOne(
+                    {
+                        **query_base,
+                        "$or": [
+                            {"company_id": {"$ne": company_id}},
+                            {"bucket": {"$ne": bucket}},
+                        ],
+                    },
+                    generic_update,
+                    upsert=False,
+                )
+            )
+
     if ops:
         USER_META.bulk_write(ops)
 
-    filter_query = {'user_id': uid, 'question_id': {'$in': ids}}
+    filter_query = {"user_id": uid, "question_id": {"$in": ids}}
     if company_id:
-        filter_query.update({'company_id': company_id, 'bucket': bucket})
-    meta_docs = {
-        m['question_id']: m
-        for m in USER_META.find(filter_query)
-    }
+        filter_query.update({"company_id": company_id, "bucket": bucket})
+    meta_docs = {m["question_id"]: m for m in USER_META.find(filter_query)}
 
     results = []
     for qid in ids:
         meta = meta_docs.get(qid, {})
-        results.append({
-            'question_id':    qid,
-            'solved':         meta.get('solved', False),
-            'userDifficulty': meta.get('userDifficulty')
-        })
+        results.append(
+            {
+                "question_id": qid,
+                "solved": meta.get("solved", False),
+                "userDifficulty": meta.get("userDifficulty"),
+            }
+        )
 
     return jsonify(results), 200
 
+
 # ─── Global Question Search Endpoints ─────────────────────────────────────
 
-@app.route('/api/questions/suggestions', methods=['GET'])
+
+@app.route("/api/questions/suggestions", methods=["GET"])
 @jwt_required()
 def question_suggestions():
     """Return question title suggestions across all companies."""
-    query = request.args.get('query', '').strip()
-    limit = int(request.args.get('limit', 10))
+    query = request.args.get("query", "").strip()
+    limit = int(request.args.get("limit", 10))
     if not query:
-        return jsonify({'suggestions': []}), 200
+        return jsonify({"suggestions": []}), 200
     if len(query) > 100:
-        abort(400, description='Query too long')
+        abort(400, description="Query too long")
     regex = re.escape(query)
     docs = QUEST.find(
-        {'title': {'$regex': regex, '$options': 'i'}},
-        {'title': 1}
+        {"title": {"$regex": regex, "$options": "i"}}, {"title": 1}
     ).limit(limit)
-    suggestions = [{'id': str(d['_id']), 'title': d['title']} for d in docs]
-    return jsonify({'suggestions': suggestions}), 200
+    suggestions = [{"id": str(d["_id"]), "title": d["title"]} for d in docs]
+    return jsonify({"suggestions": suggestions}), 200
 
 
-@app.route('/api/questions/<question_id>/companies', methods=['GET'])
+@app.route("/api/questions/<question_id>/companies", methods=["GET"])
 @jwt_required()
 def question_companies(question_id):
     """List companies that include the given question in any bucket."""
@@ -1224,23 +1330,26 @@ def question_companies(question_id):
         abort(400, description=f"Invalid question ID '{question_id}'")
 
     pipeline = [
-        {'$match': {'question_id': q_oid}},
-        {'$lookup': {
-            'from': 'companies',
-            'localField': 'company_id',
-            'foreignField': '_id',
-            'as': 'co'
-        }},
-        {'$unwind': '$co'},
-        {'$group': {'_id': '$co.name'}},
-        {'$sort': {'_id': 1}}
+        {"$match": {"question_id": q_oid}},
+        {
+            "$lookup": {
+                "from": "companies",
+                "localField": "company_id",
+                "foreignField": "_id",
+                "as": "co",
+            }
+        },
+        {"$unwind": "$co"},
+        {"$group": {"_id": "$co.name"}},
+        {"$sort": {"_id": 1}},
     ]
     results = list(CQ.aggregate(pipeline))
-    companies = [r['_id'] for r in results]
-    return jsonify({'companies': companies}), 200
+    companies = [r["_id"] for r in results]
+    return jsonify({"companies": companies}), 200
+
 
 # ─── Company-wide progress (per bucket) ───────────────────────────────────
-@app.route('/api/companies/<company>/progress', methods=['GET'])
+@app.route("/api/companies/<company>/progress", methods=["GET"])
 @jwt_required()
 def company_progress(company):
     """
@@ -1258,116 +1367,128 @@ def company_progress(company):
     uid = get_jwt_identity()
 
     # 1) Find the company document
-    co = COMPANIES.find_one({'name': company})
+    co = COMPANIES.find_one({"name": company})
     if not co:
         abort(404, description=f"No company '{company}'")
 
     # 2) Aggregate: for each bucket, count total vs. solved
     pipeline = [
-        { '$match': { 'company_id': co['_id'] } },
-        { '$lookup': {
-            'from': 'user_meta',
-            'let': { 'qid': '$question_id' },
-            'pipeline': [
-                { '$match': {
-                    '$expr': {
-                        '$and': [
-                            # user_meta.question_id is stored as STRING, so compare to stringified ObjectId
-                            { '$eq': [ '$question_id', { '$toString': '$$qid' } ] },
-                            { '$eq': [ '$user_id', uid ] }
+        {"$match": {"company_id": co["_id"]}},
+        {
+            "$lookup": {
+                "from": "user_meta",
+                "let": {"qid": "$question_id"},
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {
+                                "$and": [
+                                    # user_meta.question_id is stored as STRING, so compare to stringified ObjectId
+                                    {"$eq": ["$question_id", {"$toString": "$$qid"}]},
+                                    {"$eq": ["$user_id", uid]},
+                                ]
+                            }
+                        }
+                    },
+                    {"$project": {"solved": 1, "_id": 0}},
+                ],
+                "as": "meta",
+            }
+        },
+        {
+            "$group": {
+                "_id": "$bucket",
+                "total": {"$sum": 1},
+                # If meta array is non-empty and meta[0].solved == true, count as solved
+                "solved": {
+                    "$sum": {
+                        "$cond": [
+                            {
+                                "$and": [
+                                    {"$ne": ["$meta", []]},
+                                    {
+                                        "$eq": [
+                                            {"$arrayElemAt": ["$meta.solved", 0]},
+                                            True,
+                                        ]
+                                    },
+                                ]
+                            },
+                            1,
+                            0,
                         ]
                     }
-                }},
-                { '$project': { 'solved': 1, '_id': 0 } }
-            ],
-            'as': 'meta'
-        }},
-        { '$group': {
-            '_id': '$bucket',
-            'total': { '$sum': 1 },
-            # If meta array is non-empty and meta[0].solved == true, count as solved
-            'solved': {
-                '$sum': {
-                    '$cond': [
-                        {
-                          '$and': [
-                            { '$ne': [ '$meta', [] ] },
-                            { '$eq': [ { '$arrayElemAt': [ '$meta.solved', 0 ] }, True ] }
-                          ]
-                        },
-                        1,
-                        0
-                      ]
-                }
+                },
             }
-        }},
-        { '$project': {
-            'bucket': '$_id',
-            'total': 1,
-            'solved': 1,
-            '_id': 0
-        }}
+        },
+        {"$project": {"bucket": "$_id", "total": 1, "solved": 1, "_id": 0}},
     ]
 
     results = list(CQ.aggregate(pipeline))
 
     # Fill in missing buckets with total=0, solved=0
     BUCKET_ORDER = ["30Days", "3Months", "6Months", "MoreThan6Months", "All"]
-    bucket_map = { r['bucket']: r for r in results }
+    bucket_map = {r["bucket"]: r for r in results}
     final_list = []
     for b in BUCKET_ORDER:
         if b in bucket_map:
             final_list.append(bucket_map[b])
         else:
-            final_list.append({ 'bucket': b, 'total': 0, 'solved': 0 })
+            final_list.append({"bucket": b, "total": 0, "solved": 0})
     return jsonify(final_list), 200
 
+
 # ─── Recently worked buckets for Home page ───────────────────────────────
-@app.route('/api/recent-buckets', methods=['GET'])
+@app.route("/api/recent-buckets", methods=["GET"])
 @jwt_required()
 def recent_buckets():
     """Return most recently updated company buckets for the current user."""
-    uid   = get_jwt_identity()
-    limit = int(request.args.get('limit', 8))
+    uid = get_jwt_identity()
+    limit = int(request.args.get("limit", 8))
 
     pipeline = [
-
-        { '$match': {
-            'user_id': uid,
-            'company_id': { '$exists': True },
-            'bucket': { '$exists': True },
-            'updatedAt': { '$exists': True }
-        }},
-        { '$sort': { 'updatedAt': -1 } },
-        { '$lookup': {
-            'from': 'companies',
-            'localField': 'company_id',
-
-            'foreignField': '_id',
-            'as': 'co'
-        }},
-        { '$unwind': '$co' },
-        { '$group': {
-
-            '_id': { 'company': '$co.name', 'bucket': '$bucket' },
-
-            'updatedAt': { '$first': '$updatedAt' }
-        }},
-        { '$sort': { 'updatedAt': -1 } },
-        { '$limit': limit },
-        { '$project': {
-            '_id': 0,
-            'company': '$_id.company',
-            'bucket': '$_id.bucket',
-            'updatedAt': 1
-        }}
+        {
+            "$match": {
+                "user_id": uid,
+                "company_id": {"$exists": True},
+                "bucket": {"$exists": True},
+                "updatedAt": {"$exists": True},
+            }
+        },
+        {"$sort": {"updatedAt": -1}},
+        {
+            "$lookup": {
+                "from": "companies",
+                "localField": "company_id",
+                "foreignField": "_id",
+                "as": "co",
+            }
+        },
+        {"$unwind": "$co"},
+        {
+            "$group": {
+                "_id": {"company": "$co.name", "bucket": "$bucket"},
+                "updatedAt": {"$first": "$updatedAt"},
+            }
+        },
+        {"$sort": {"updatedAt": -1}},
+        {"$limit": limit},
+        {
+            "$project": {
+                "_id": 0,
+                "company": "$_id.company",
+                "bucket": "$_id.bucket",
+                "updatedAt": 1,
+            }
+        },
     ]
 
     results = list(USER_META.aggregate(pipeline))
-    return jsonify({'data': results}), 200
+    return jsonify({"data": results}), 200
+
 
 # ─── Aggregate user statistics for Home page ─────────────────────────────
-@app.route('/api/user-stats', methods=['GET'])
+@app.route("/api/user-stats", methods=["GET"])
 @jwt_required()
 def user_stats():
     """Return solved/attempted counts and per-company breakdown."""
@@ -1375,103 +1496,101 @@ def user_stats():
 
     cached = STATS_CACHE.get(uid)
     now = datetime.utcnow()
-    if cached and (now - cached['ts']).total_seconds() < STATS_TTL_SECONDS:
-        if 'totalQuestions' in cached['data']:
-            return jsonify(cached['data']), 200
+    if cached and (now - cached["ts"]).total_seconds() < STATS_TTL_SECONDS:
+        if "totalQuestions" in cached["data"]:
+            return jsonify(cached["data"]), 200
 
-    total_attempted = USER_META.count_documents({'user_id': uid})
-    total_solved = USER_META.count_documents({'user_id': uid, 'solved': True})
+    total_attempted = USER_META.count_documents({"user_id": uid})
+    total_solved = USER_META.count_documents({"user_id": uid, "solved": True})
 
     diff_pipeline = [
-        {'$match': {'user_id': uid, 'solved': True}},
-
+        {"$match": {"user_id": uid, "solved": True}},
         {
-            '$lookup': {
-                'from': 'questions',
-                'let': {'qid': '$question_id'},
-                'pipeline': [
-                    {
-                        '$match': {
-                            '$expr': {
-                                '$eq': ['$_id', {'$toObjectId': '$$qid'}]
-                            }
-                        }
-                    },
-                    {'$project': {'leetDifficulty': 1}}
+            "$lookup": {
+                "from": "questions",
+                "let": {"qid": "$question_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$_id", {"$toObjectId": "$$qid"}]}}},
+                    {"$project": {"leetDifficulty": 1}},
                 ],
-                'as': 'q'
+                "as": "q",
             }
         },
-        {'$unwind': '$q'},
-        {'$group': {'_id': '$q.leetDifficulty', 'count': {'$sum': 1}}}
+        {"$unwind": "$q"},
+        {"$group": {"_id": "$q.leetDifficulty", "count": {"$sum": 1}}},
     ]
-    raw_counts = {d['_id']: d['count'] for d in USER_META.aggregate(diff_pipeline)}
-    diff_counts = {'Easy': 0, 'Medium': 0, 'Hard': 0}
+    raw_counts = {d["_id"]: d["count"] for d in USER_META.aggregate(diff_pipeline)}
+    diff_counts = {"Easy": 0, "Medium": 0, "Hard": 0}
     for k, v in raw_counts.items():
         key = str(k).strip().capitalize()
         if key in diff_counts:
             diff_counts[key] += v
 
-
     company_pipeline = [
-        {'$match': {'bucket': 'All'}},
-        {'$lookup': {
-            'from': 'user_meta',
-            'let': {'qid': '$question_id'},
-            'pipeline': [
-                {'$match': {
-                    '$expr': {
-                        '$and': [
-                            {'$eq': ['$question_id', {'$toString': '$$qid'}]},
-                            {'$eq': ['$user_id', uid]},
-                            {'$eq': ['$solved', True]}
-                        ]
-                    }
-                }},
-                {'$project': {'_id': 0}}
-            ],
-            'as': 'meta'
-        }},
-        {'$lookup': {
-            'from': 'companies',
-            'localField': 'company_id',
-            'foreignField': '_id',
-            'as': 'co'
-        }},
-        {'$unwind': '$co'},
-        {'$group': {
-            '_id': '$co.name',
-            'total': {'$sum': 1},
-            'solved': {'$sum': {'$cond': [{'$gt': [{'$size': '$meta'}, 0]}, 1, 0]}}
-        }},
-        {'$project': {'company': '$_id', 'total': 1, 'solved': 1, '_id': 0}},
-        {'$sort': {'company': 1}}
+        {"$match": {"bucket": "All"}},
+        {
+            "$lookup": {
+                "from": "user_meta",
+                "let": {"qid": "$question_id"},
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {
+                                "$and": [
+                                    {"$eq": ["$question_id", {"$toString": "$$qid"}]},
+                                    {"$eq": ["$user_id", uid]},
+                                    {"$eq": ["$solved", True]},
+                                ]
+                            }
+                        }
+                    },
+                    {"$project": {"_id": 0}},
+                ],
+                "as": "meta",
+            }
+        },
+        {
+            "$lookup": {
+                "from": "companies",
+                "localField": "company_id",
+                "foreignField": "_id",
+                "as": "co",
+            }
+        },
+        {"$unwind": "$co"},
+        {
+            "$group": {
+                "_id": "$co.name",
+                "total": {"$sum": 1},
+                "solved": {"$sum": {"$cond": [{"$gt": [{"$size": "$meta"}, 0]}, 1, 0]}},
+            }
+        },
+        {"$project": {"company": "$_id", "total": 1, "solved": 1, "_id": 0}},
+        {"$sort": {"company": 1}},
     ]
     company_stats = list(CQ.aggregate(company_pipeline))
 
-
     # Count unique question slugs across all companies to avoid duplicates
-    qids = CQ.distinct('question_id')
-    links = [q.get('link', '') for q in QUEST.find({'_id': {'$in': qids}}, {'link': 1})]
+    qids = CQ.distinct("question_id")
+    links = [q.get("link", "") for q in QUEST.find({"_id": {"$in": qids}}, {"link": 1})]
     slugs = {
-        link.rstrip('/').split('/')[-1].split('?')[0].lower()
-        for link in links if link
+        link.rstrip("/").split("/")[-1].split("?")[0].lower() for link in links if link
     }
     total_questions = len(slugs)
 
-
     data = {
-        'totalSolved': total_solved,
-        'totalAttempted': total_attempted,
-        'totalQuestions': total_questions,
-        'difficulty': diff_counts,
-        'companies': company_stats
+        "totalSolved": total_solved,
+        "totalAttempted": total_attempted,
+        "totalQuestions": total_questions,
+        "difficulty": diff_counts,
+        "companies": company_stats,
     }
-    STATS_CACHE[uid] = {'ts': now, 'data': data}
+    STATS_CACHE[uid] = {"ts": now, "data": data}
     return jsonify(data), 200
 
+
 # ─── Ask AI Chat Endpoint ───────────────────────────────────────────────
-@app.route('/api/ask-ai/<question_id>', methods=['GET', 'POST'])
+@app.route("/api/ask-ai/<question_id>", methods=["GET", "POST"])
 @jwt_required()
 def ask_ai(question_id):
     uid = get_jwt_identity()
@@ -1480,24 +1599,24 @@ def ask_ai(question_id):
     except InvalidId:
         abort(400, description=f"Invalid question ID '{question_id}'")
 
-    q = QUEST.find_one({'_id': q_oid})
+    q = QUEST.find_one({"_id": q_oid})
     if not q:
         abort(404, description=f"Question '{question_id}' not found")
 
-    slug = q['link'].rstrip('/').split('/')[-1]
+    slug = q["link"].rstrip("/").split("/")[-1]
     content = fetch_leetcode_content(slug)
-    tags = q.get('tags', [])
-    title = q.get('title')
+    tags = q.get("tags", [])
+    title = q.get("title")
 
-    threads = session.setdefault('ai_threads', {})
+    threads = session.setdefault("ai_threads", {})
     thread = threads.setdefault(f"{uid}:{question_id}", [])
 
-    if request.method == 'POST':
+    if request.method == "POST":
         data = request.get_json() or {}
-        message = sanitize_text(data.get('message', ''))
+        message = sanitize_text(data.get("message", ""))
         if not message:
-            abort(400, description='message required')
-        thread.append({'role': 'user', 'content': message})
+            abort(400, description="message required")
+        thread.append({"role": "user", "content": message})
 
         system_prompt = (
             "You are a helpful and precise AI coding assistant. "
@@ -1508,10 +1627,10 @@ def ask_ai(question_id):
             "Do not compress code into a single line unless explicitly asked to."
         )
         messages = [
-            {'role': 'system', 'content': system_prompt},
+            {"role": "system", "content": system_prompt},
             {
-                'role': 'assistant',
-                'content': (
+                "role": "assistant",
+                "content": (
                     f"The user is trying to solve the following question: {title}. "
                     f"{content or ''} The tags are {', '.join(tags)}. "
                     "Provide helpful hints or explanations. Avoid directly giving the full answer unless requested."
@@ -1523,38 +1642,57 @@ def ask_ai(question_id):
         if OPENROUTER_API_KEY:
             try:
                 r = requests.post(
-                    'https://openrouter.ai/api/v1/chat/completions',
+                    "https://openrouter.ai/api/v1/chat/completions",
                     headers={
-                        'Authorization': f'Bearer {OPENROUTER_API_KEY}',
-                        'Content-Type': 'application/json',
-                        'HTTP-Referer': 'https://github.com/tchawla827/LeetEase',
-                        'X-Title': 'LeetEase',
+                        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+                        "Content-Type": "application/json",
+                        "HTTP-Referer": "https://github.com/tchawla827/LeetEase",
+                        "X-Title": "LeetEase",
                     },
-                    json={'model': 'qwen/qwen-2.5-coder-32b-instruct:free', 'messages': messages},
+                    json={
+                        "model": "qwen/qwen-2.5-coder-32b-instruct:free",
+                        "messages": messages,
+                    },
                     timeout=10,
                 )
                 r.raise_for_status()
-                ai_resp = r.json()['choices'][0]['message']['content']
+                ai_resp = r.json()["choices"][0]["message"]["content"]
             except Exception as e:
-                app.logger.error('OpenRouter request failed: %s', e)
+                app.logger.error("OpenRouter request failed: %s", e)
                 ai_resp = "Sorry, I'm unable to generate a hint right now."
         else:
             ai_resp = "OpenRouter API key not configured."
 
-        thread.append({'role': 'assistant', 'content': ai_resp})
+        thread.append({"role": "assistant", "content": ai_resp})
         session.modified = True
-        return jsonify({'thread': thread}), 200
+        return jsonify({"thread": thread}), 200
 
     # GET request returns existing thread
-    return jsonify({'thread': thread, 'title': title, 'content': content, 'tags': tags, 'link': q.get('link')}), 200
+    return (
+        jsonify(
+            {
+                "thread": thread,
+                "title": title,
+                "content": content,
+                "tags": tags,
+                "link": q.get("link"),
+            }
+        ),
+        200,
+    )
+
 
 # ─── Run & Startup Sync ────────────────────────────────────────────────────
 def _startup_sync():
     """Sync every user who has both handle & session saved."""
-    users = list(USERS.find({
-        'leetcode_username': {'$exists': True},
-        'leetcode_session':  {'$exists': True}
-    }))
+    users = list(
+        USERS.find(
+            {
+                "leetcode_username": {"$exists": True},
+                "leetcode_session": {"$exists": True},
+            }
+        )
+    )
 
     if not users:
         return
@@ -1563,10 +1701,10 @@ def _startup_sync():
         future_to_uid = {
             executor.submit(
                 sync_leetcode,
-                u['leetcode_username'],
-                u['leetcode_session'],
-                str(u['_id'])
-            ): u['_id']
+                u["leetcode_username"],
+                u["leetcode_session"],
+                str(u["_id"]),
+            ): u["_id"]
             for u in users
         }
         for fut in concurrent.futures.as_completed(future_to_uid):
@@ -1576,36 +1714,38 @@ def _startup_sync():
             except Exception as e:
                 app.logger.warning("Startup sync failed for %s: %s", uid, e)
 
+
 # ─── Serve React Frontend ────────────────────────────────────────────────
-@app.route('/', defaults={'path': ''})
-@app.route('/<path:path>')
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
 def serve_react(path: str):
     """Serve the React single-page application."""
-    if path.startswith('api/') or path.startswith('uploads/'):
+    if path.startswith("api/") or path.startswith("uploads/"):
         abort(404)
 
-    build_dir = os.path.join(BASE_DIR, 'frontend', 'build')
-    public_dir = os.path.join(BASE_DIR, 'frontend', 'public')
+    build_dir = os.path.join(BASE_DIR, "frontend", "build")
+    public_dir = os.path.join(BASE_DIR, "frontend", "public")
 
     target = os.path.join(build_dir, path)
     if os.path.exists(target) and os.path.isfile(target):
         return send_from_directory(build_dir, path)
 
-    index_build = os.path.join(build_dir, 'index.html')
+    index_build = os.path.join(build_dir, "index.html")
     if os.path.exists(index_build):
-        return send_from_directory(build_dir, 'index.html')
+        return send_from_directory(build_dir, "index.html")
 
     target_public = os.path.join(public_dir, path)
     if os.path.exists(target_public) and os.path.isfile(target_public):
         return send_from_directory(public_dir, path)
-    return send_from_directory(public_dir, 'index.html')
+    return send_from_directory(public_dir, "index.html")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # If you want to perform a one-time sync on startup, uncomment below:
     # _startup_sync()
-    debug_env = os.getenv('FLASK_DEBUG', '').lower()
-    debug = debug_env in ('1', 'true', 'yes')
+    debug_env = os.getenv("FLASK_DEBUG", "").lower()
+    debug = debug_env in ("1", "true", "yes")
 
-    host = os.getenv('FLASK_RUN_HOST', '0.0.0.0')
-    port = int(os.getenv('FLASK_RUN_PORT', 5000))
+    host = os.getenv("FLASK_RUN_HOST", "0.0.0.0")
+    port = int(os.getenv("FLASK_RUN_PORT", 5000))
     app.run(host=host, port=port, debug=debug)

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,19 +22,24 @@ if not MONGODB_URI:
     raise RuntimeError("MONGODB_URI not set in .env")
 
 _client = MongoClient(MONGODB_URI)
+
+
 def get_db():
     return _client.get_default_database()
 
+
 def ensure_indexes(db):
     """Create indexes used across the application."""
-    db.questions.create_index('link', unique=True)
-    db.companies.create_index('name', unique=True)
+    db.questions.create_index("link", unique=True)
+    db.questions.create_index("slug", unique=True)
+    db.companies.create_index("name", unique=True)
     db.company_questions.create_index(
-        [('company_id', 1), ('bucket', 1), ('question_id', 1)], unique=True
+        [("company_id", 1), ("bucket", 1), ("question_id", 1)], unique=True
     )
-    db.company_questions.create_index('question_id')
-    db.user_meta.create_index([('user_id', 1), ('question_id', 1)])
-    db.user_meta.create_index([('user_id', 1), ('company_id', 1), ('bucket', 1)])
+    db.company_questions.create_index("question_id")
+    db.user_meta.create_index([("user_id", 1), ("question_id", 1)])
+    db.user_meta.create_index([("user_id", 1), ("company_id", 1), ("bucket", 1)])
+
 
 # ————————————————
 # Flask-JWT-Extended
@@ -49,7 +54,11 @@ JWT_ACCESS_TOKEN_EXPIRES = timedelta(
 # Store tokens in headers and cookies
 JWT_TOKEN_LOCATION = ["headers", "cookies"]
 # Cookie is sent only over HTTPS by default. Override with JWT_COOKIE_SECURE=False for local testing.
-JWT_COOKIE_SECURE = os.getenv("JWT_COOKIE_SECURE", "True").lower() in ("true", "1", "yes")
+JWT_COOKIE_SECURE = os.getenv("JWT_COOKIE_SECURE", "True").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 JWT_COOKIE_SAMESITE = os.getenv("JWT_COOKIE_SAMESITE", "Lax")
 JWT_COOKIE_CSRF_PROTECT = False
 
@@ -62,7 +71,11 @@ SESSION_USE_SIGNER = True
 SESSION_FILE_DIR = os.getenv("SESSION_FILE_DIR", "./.flask_session/")
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = "Lax"
-SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "True").lower() in ("true", "1", "yes")
+SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "True").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 WTF_CSRF_TIME_LIMIT = None
 
 # ————————————————

--- a/backend/modules/loader.py
+++ b/backend/modules/loader.py
@@ -18,60 +18,75 @@ import os
 from pathlib import Path
 import pandas as pd
 from bson import ObjectId
+import re
 from backend.config import get_db
 
 # ── CSV bucket filenames → bucket key ───────────────────────────────────
 BUCKET_MAP = {
-    "1. Thirty Days.csv":          "30Days",
-    "2. Three Months.csv":         "3Months",
-    "3. Six Months.csv":           "6Months",
+    "1. Thirty Days.csv": "30Days",
+    "2. Three Months.csv": "3Months",
+    "3. Six Months.csv": "6Months",
     "4. More Than Six Months.csv": "MoreThan6Months",
-    "5. All.csv":                  "All"
+    "5. All.csv": "All",
 }
 
 # ── Collections ────────────────────────────────────────────────────────
-db  = get_db()
-Q   = db.questions           # canonical
-CO  = db.companies
-CQ  = db.company_questions
+db = get_db()
+Q = db.questions  # canonical
+CO = db.companies
+CQ = db.company_questions
 
 # ── Build indexes once ─────────────────────────────────────────────────
-Q.create_index('link', unique=True)
-CO.create_index('name', unique=True)
-CQ.create_index([('company_id',1), ('bucket',1)])
-CQ.create_index('question_id')
+Q.create_index("link", unique=True)
+Q.create_index("slug", unique=True)
+CO.create_index("name", unique=True)
+CQ.create_index([("company_id", 1), ("bucket", 1)])
+CQ.create_index("question_id")
 
 # ── Helper caches to minimise round-trips ──────────────────────────────
-company_id_cache  = {}   # name  -> ObjectId
-question_id_cache = {}   # link  -> ObjectId
+company_id_cache = {}  # name  -> ObjectId
+question_id_cache = {}  # slug -> ObjectId
+
 
 def get_company_id(name: str) -> ObjectId:
     if name in company_id_cache:
         return company_id_cache[name]
     doc = CO.find_one_and_update(
-        {'name': name},
-        {'$setOnInsert': {'name': name}},
+        {"name": name},
+        {"$setOnInsert": {"name": name}},
         upsert=True,
-        return_document=True
+        return_document=True,
     )
-    company_id_cache[name] = doc['_id']
-    return doc['_id']
+    company_id_cache[name] = doc["_id"]
+    return doc["_id"]
+
+
+def slug_from_link(link: str) -> str:
+    slug = re.sub(r"/+$", "", link.strip())
+    slug = slug.split("?")[0]
+    return slug.rsplit("/", 1)[-1]
+
 
 def get_question_id(link: str, title: str, leet_diff: str) -> ObjectId:
-    if link in question_id_cache:
-        return question_id_cache[link]
+    slug = slug_from_link(link)
+    if slug in question_id_cache:
+        return question_id_cache[slug]
     doc = Q.find_one_and_update(
-        {'link': link},
-        {'$setOnInsert': {
-            'link': link,
-            'title': title,
-            'leetDifficulty': leet_diff
-        }},
+        {"$or": [{"link": link}, {"slug": slug}]},
+        {
+            "$setOnInsert": {
+                "link": link,
+                "slug": slug,
+                "title": title,
+                "leetDifficulty": leet_diff,
+            }
+        },
         upsert=True,
-        return_document=True
+        return_document=True,
     )
-    question_id_cache[link] = doc['_id']
-    return doc['_id']
+    question_id_cache[slug] = doc["_id"]
+    return doc["_id"]
+
 
 # ── Loader main ────────────────────────────────────────────────────────
 def load_company_data(data_root: str | Path | None = None):
@@ -101,36 +116,40 @@ def load_company_data(data_root: str | Path | None = None):
             df.columns = [c.strip() for c in df.columns]
 
             for _, row in df.iterrows():
-                title   = str(row.get("Title") or row.get("Question") or "").strip()
-                link    = str(row.get("Link")  or "").strip()
-                freq    = float(row.get("Frequency") or 0)
-                acc     = float(row.get("Acceptance Rate") or row.get("AcceptanceRate") or 0)
-                ldiff   = str(row.get("Difficulty") or "").capitalize().strip()
+                title = str(row.get("Title") or row.get("Question") or "").strip()
+                link = str(row.get("Link") or "").strip()
+                freq = float(row.get("Frequency") or 0)
+                acc = float(
+                    row.get("Acceptance Rate") or row.get("AcceptanceRate") or 0
+                )
+                ldiff = str(row.get("Difficulty") or "").capitalize().strip()
 
                 if not link:
                     continue  # skip malformed rows
 
                 qid = get_question_id(link, title, ldiff)
 
-                batch.append({
-                    'company_id'    : cid,
-                    'question_id'   : qid,
-                    'bucket'        : bucket,
-                    'frequency'     : freq,
-                    'acceptanceRate': acc
-                })
+                batch.append(
+                    {
+                        "company_id": cid,
+                        "question_id": qid,
+                        "bucket": bucket,
+                        "frequency": freq,
+                        "acceptanceRate": acc,
+                    }
+                )
 
         if batch:
             # Upsert each pair; replaceOne keeps stats idempotent
             for doc in batch:
                 CQ.replace_one(
                     {
-                        'company_id' : doc['company_id'],
-                        'question_id': doc['question_id'],
-                        'bucket'     : doc['bucket']
+                        "company_id": doc["company_id"],
+                        "question_id": doc["question_id"],
+                        "bucket": doc["bucket"],
                     },
                     doc,
-                    upsert=True
+                    upsert=True,
                 )
         print(f"  ✔ added/updated {len(batch)} bucket rows")
         total_cq += len(batch)
@@ -141,6 +160,8 @@ def load_company_data(data_root: str | Path | None = None):
     print("  company_questions :", CQ.count_documents({}))
     print(f"  rows processed    : {total_cq}")
 
+
 if __name__ == "__main__":
     import sys
+
     load_company_data(sys.argv[1] if len(sys.argv) > 1 else None)


### PR DESCRIPTION
## Summary
- track question slug for deduplication and add unique index
- default sort questions by title
- keep user meta (solved & difficulty) in sync across all buckets

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6869fef03fd083219ee630d96d2181ea