### PR TITLE
Add clear buttons for search inputs

### DIFF
--- a/frontend/src/components/CompanyStats.jsx
+++ b/frontend/src/components/CompanyStats.jsx
@@ -53,14 +53,23 @@ export default function CompanyStats() {
   return (
     <div className="bg-surface rounded-card border border-gray-300 dark:border-gray-800 shadow-elevation p-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div className="flex-1 max-w-xs">
+        <div className="flex-1 max-w-xs relative">
           <input
             type="text"
             value={filter}
             onChange={e => setFilter(e.target.value)}
             placeholder="Search companies…"
-            className="w-full bg-background border border-gray-300 dark:border-gray-700 text-foreground rounded-lg px-4 py-2.5 text-sm placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all hover:border-gray-400 dark:hover:border-gray-600"
+            className="w-full bg-background border border-gray-300 dark:border-gray-700 text-foreground rounded-lg px-4 py-2.5 pr-8 text-sm placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all hover:border-gray-400 dark:hover:border-gray-600"
           />
+          {filter && (
+            <button
+              onClick={() => setFilter('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Clear search"
+            >
+              ×
+            </button>
+          )}
         </div>
         <div className="flex items-center gap-3">
           <label 

--- a/frontend/src/components/QuestionSearch.js
+++ b/frontend/src/components/QuestionSearch.js
@@ -65,8 +65,29 @@ export default function QuestionSearch({ company, bucket, onSearch }) {
     placeholder: 'Search questions...',
     value,
     onChange,
-    className: 'w-full px-3 py-2 text-code-sm bg-gray-800 text-white placeholder-gray-400 border border-gray-600 rounded-code focus:outline-none focus:ring-2 focus:ring-yellow-400/50 focus:border-yellow-400/50'
+    className: 'w-full px-3 py-2 pr-8 text-code-sm bg-gray-800 text-white placeholder-gray-400 border border-gray-600 rounded-code focus:outline-none focus:ring-2 focus:ring-yellow-400/50 focus:border-yellow-400/50'
   };
+
+  const clearSearch = () => {
+    setValue('');
+    onSearch('');
+    setSuggestions([]);
+  };
+
+  const renderInput = inputProps => (
+    <div className="relative">
+      <input {...inputProps} />
+      {value && (
+        <button
+          onClick={e => { e.preventDefault(); clearSearch(); }}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+          aria-label="Clear search"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
 
   return (
     <div className="relative my-4">
@@ -78,6 +99,7 @@ export default function QuestionSearch({ company, bucket, onSearch }) {
         renderSuggestion={renderSuggestion}
         onSuggestionSelected={onSuggestionSelected}
         inputProps={inputProps}
+        renderInputComponent={renderInput}
         theme={{
           container: 'relative',
           suggestionsContainer: 'absolute w-full bg-gray-800 border border-gray-600 mt-1 rounded-code shadow-lg z-10',

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -150,18 +150,29 @@ export default function Sidebar({ sidebarOpen }) {
               Companies
             </h2>
 
-            <input
-              type="text"
-              placeholder="Search companies…"
-              value={filter}
-              onChange={e => setFilter(e.target.value)}
-              className="
-                font-mono text-code-sm w-full px-3 py-1.5 mb-2
-                rounded-code border border-gray-700 bg-gray-900
-                text-gray-900 dark:text-gray-100 placeholder-gray-500
-                focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/50
-              "
-            />
+            <div className="relative mb-2">
+              <input
+                type="text"
+                placeholder="Search companies…"
+                value={filter}
+                onChange={e => setFilter(e.target.value)}
+                className="
+                  font-mono text-code-sm w-full px-3 py-1.5 pr-8
+                  rounded-code border border-gray-700 bg-gray-900
+                  text-gray-900 dark:text-gray-100 placeholder-gray-500
+                  focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/50
+                "
+              />
+              {filter && (
+                <button
+                  onClick={() => setFilter('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+                  aria-label="Clear search"
+                >
+                  ×
+                </button>
+              )}
+            </div>
 
             <ul className="divide-y divide-gray-800">
               {filteredCompanies.map(company => {

--- a/frontend/src/pages/CompanyPage.js
+++ b/frontend/src/pages/CompanyPage.js
@@ -225,13 +225,27 @@ export default function CompanyPage() {
       {selectedBucket && (
         <>
           <div className="flex flex-wrap items-center gap-3 mb-4">
-            <input
-              type="text"
-              value={searchInput}
-              onChange={handleSearchChange}
-              placeholder="Search questions..."
-              className="flex-1 px-4 py-2 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-700 rounded-code placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary"
-            />
+            <div className="relative flex-1">
+              <input
+                type="text"
+                value={searchInput}
+                onChange={handleSearchChange}
+                placeholder="Search questions..."
+                className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-700 rounded-code placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary pr-8"
+              />
+              {searchInput && (
+                <button
+                  onClick={() => {
+                    setSearchInput('');
+                    setSearchTerm('');
+                  }}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  aria-label="Clear search"
+                >
+                  ×
+                </button>
+              )}
+            </div>
             <button
               onClick={() => {
                 setRefreshKey(k => k + 1)

--- a/frontend/src/pages/SearchQuestions.jsx
+++ b/frontend/src/pages/SearchQuestions.jsx
@@ -56,8 +56,29 @@ export default function SearchQuestions() {
     placeholder: 'Search questions...',
     value,
     onChange,
-    className: 'w-full px-3 py-2 text-code-sm bg-gray-800 text-white placeholder-gray-400 border border-gray-600 rounded-code focus:outline-none focus:ring-2 focus:ring-yellow-400/50 focus:border-yellow-400/50'
+    className: 'w-full px-3 py-2 pr-8 text-code-sm bg-gray-800 text-white placeholder-gray-400 border border-gray-600 rounded-code focus:outline-none focus:ring-2 focus:ring-yellow-400/50 focus:border-yellow-400/50'
   };
+
+  const clearSearch = () => {
+    setValue('');
+    setSuggestions([]);
+    setCompanies([]);
+  };
+
+  const renderInput = inputProps => (
+    <div className="relative">
+      <input {...inputProps} />
+      {value && (
+        <button
+          onClick={e => { e.preventDefault(); clearSearch(); }}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+          aria-label="Clear search"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
 
   return (
     <div className="max-w-xl mx-auto mt-8">
@@ -69,6 +90,7 @@ export default function SearchQuestions() {
         renderSuggestion={renderSuggestion}
         onSuggestionSelected={onSuggestionSelected}
         inputProps={inputProps}
+        renderInputComponent={renderInput}
         theme={{
           container: 'relative',
           suggestionsContainer: 'absolute w-full bg-gray-800 border border-gray-600 mt-1 rounded-code shadow-lg z-10',


### PR DESCRIPTION
## Summary
- allow clearing company search filters
- allow clearing sidebar company search
- allow clearing question page search
- allow clearing suggestion inputs

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68836f10785083219114e0148c8d7490