### PR TITLE
Add home icon to navbar

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -232,6 +232,26 @@ export default function Navbar({
 
         {/* ─── Right: Avatar (Desktop / Mobile) ──────────────────────────────────── */}
         <div className="ml-auto flex items-center gap-code">
+          <Link
+            to={user ? '/home' : '/'}
+            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none"
+            aria-label="Home"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="h-6 w-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+              />
+            </svg>
+          </Link>
           <button
             onClick={toggleTheme}
             className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none"


### PR DESCRIPTION
## Summary
- add a Home icon button to the navbar linking to the home page

## Testing
- `python -m unittest discover tests`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6883a3a5659c8321a36432e85f5ec7ef